### PR TITLE
build: adopt typescript 6 (fix tsup DTS baseUrl deprecation)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -512,8 +512,8 @@ packages:
       typescript:
         optional: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -876,7 +876,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(jiti@2.7.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.7.0)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -896,13 +896,13 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.4: {}


### PR DESCRIPTION
## What

Supersedes #3 (Dependabot's `typescript` 5.9.3 → 6.0.3 bump, which fails CI).

### Root cause
The bump itself isn't the problem. `tsup`'s DTS build program sets the deprecated `baseUrl` compiler option internally, and TypeScript 6 promotes deprecated options to a **hard error**:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

Since `baseUrl` is injected by tsup (not by our `tsconfig.json`), the sanctioned fix is to acknowledge the deprecation via `"ignoreDeprecations": "6.0"`. It can be dropped once tsup stops emitting `baseUrl` (by TS 7, when the option is removed).

## Changes
- `packages/sdk/package.json`: `typescript` → `^6.0.3`
- `packages/sdk/tsconfig.json`: add `"ignoreDeprecations": "6.0"`
- `pnpm-lock.yaml`: refreshed

## Verified locally (ts 6.0.3)
- `pnpm -r run build` → ESM/CJS/DTS all green
- `pnpm -r run typecheck` → green

No other ts6 errors surfaced behind the deprecation.

Made with [Cursor](https://cursor.com)