### PR TITLE
chore(sdk): sync to agent_platform@c3af8fe (v0.1.0)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3564,6 +3564,19 @@
             ],
             "title": "Parent Session Id",
             "description": "Parent session id."
+          },
+          "answer_format": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Answer Format",
+            "description": "JSON Schema the final answer must conform to. Null returns free-form text."
           }
         },
         "additionalProperties": false,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "TypeScript SDK for H Company's agent API",
   "type": "module",
   "license": "MIT",

--- a/packages/sdk/src/client/types.gen.ts
+++ b/packages/sdk/src/client/types.gen.ts
@@ -816,6 +816,14 @@ export type SessionRequest = {
    * Parent session id.
    */
   parent_session_id?: string | null;
+  /**
+   * Answer Format
+   *
+   * JSON Schema the final answer must conform to. Null returns free-form text.
+   */
+  answer_format?: {
+    [key: string]: unknown;
+  } | null;
 };
 
 /**


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.0` (minor — breaking upstream change)
**Upstream:** agent_platform@c3af8fe
