### PR TITLE
Document source install fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TypeScript developer libraries and tools for [H Company's Agent Platform](https:
 
 | Package | Description |
 | --- | --- |
-| [`packages/sdk`](packages/sdk) | TypeScript SDK — a fully typed client for the Agent Platform API. Published to npm as [`hai-agents`](https://www.npmjs.com/package/hai-agents). |
+| [`packages/sdk`](packages/sdk) | TypeScript SDK — a fully typed client for the Agent Platform API. Packaged as `hai-agents`. |
 
 ## Development
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -13,4 +13,15 @@ TypeScript SDK for [H Company's Agent Platform](https://hcompany.ai). A fully ty
 npm install hai-agents
 ```
 
+If the package is not available from your npm registry yet, install from a
+repository checkout:
+
+```bash
+git clone https://github.com/hcompai/hai-agents-ts.git
+cd hai-agents-ts
+pnpm install
+pnpm -r run build
+npm install ./packages/sdk
+```
+
 Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai).


### PR DESCRIPTION
## Summary
- stop claiming the package is already published to public npm in the root README
- add a source-checkout install fallback to the SDK README for environments where `hai-agents` is not available from the configured npm registry

Closes #7

## Test
- docs-only change