### PR TITLE
docs(sdk): add usage quickstart to TypeScript README

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -14,3 +14,51 @@ npm install hai-agents
 ```
 
 Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai).
+
+## Usage
+
+Every operation takes per-call options. Set `baseUrl` to the Agent Platform and
+provide your `hk-...` key via the `auth` callback:
+
+```ts
+import {
+  createSession,
+  getSessionStatus,
+  getSessionChanges,
+} from "hai-agents";
+
+const config = {
+  baseUrl: "https://agp.eu.hcompany.ai",
+  auth: () => process.env.H_API_KEY!,
+};
+
+// Start a browsing session with the hosted `h/web` agent.
+const { data: session } = await createSession({
+  ...config,
+  body: {
+    agent: "h/web",
+    messages: [{ type: "user_message", message: "What is the H1 on example.com?" }],
+    max_steps: 10,
+    max_time_s: 150,
+  },
+});
+
+const sessionId = session!.id;
+
+// Poll until the session reaches a terminal state.
+const terminal = new Set(["completed", "failed", "timed_out", "interrupted"]);
+let status = session!.status.status;
+while (!terminal.has(status)) {
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  const { data } = await getSessionStatus({ ...config, path: { id: sessionId } });
+  status = data!.status;
+}
+
+// Read the agent's final answer.
+const { data: changes } = await getSessionChanges({
+  ...config,
+  path: { id: sessionId },
+  query: { from_index: 0 },
+});
+console.log(changes!.answer);
+```


### PR DESCRIPTION
Fixes #11

## Summary
- Adds a **Usage** section to `packages/sdk/README.md` with a minimal end-to-end quickstart: per-call config (`baseUrl` + `auth`), create an `h/web` session, poll to a terminal status, read the answer.
- Uses only the operations exported on `main` today (`createSession`, `getSessionStatus`, `getSessionChanges`) with per-call options, so it works on the current package without depending on any other open PR.

## Verification
- **Runtime**: the same call pattern was run live against `https://agp.eu.hcompany.ai` (auth check via `listAgents` → 200, session created, polled to completion, answer returned).
- **Types**: the snippet type-checks (`tsc --strict`, exit 0) against the SDK's generated types. Field names (`agent`, `messages[].type`/`message`, `max_steps`, `max_time_s`, `session.status.status`, `data.answer`) and the terminal-status set (`completed`/`failed`/`timed_out`/`interrupted`) match `types.gen.ts`.

## Note for reviewers
- This touches `packages/sdk/README.md`, same file as open PR #10 (install-fallback block). The two edits are in different regions (PR #10 inserts before the "Grab an API key" line; this appends a new section after it), so they should merge cleanly — but whichever lands second may want a quick rebase to confirm.
- The example sets `baseUrl` explicitly, so it is correct regardless of whether PR #9 (which changes the *default* `baseUrl` to prod) merges.