### PR TITLE
Document TypeScript session cancel polling

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -22,6 +22,7 @@ provide your `hk-...` key via the `auth` callback:
 
 ```ts
 import {
+  cancelSession,
   createSession,
   getSessionStatus,
   getSessionChanges,
@@ -61,4 +62,24 @@ const { data: changes } = await getSessionChanges({
   query: { from_index: 0 },
 });
 console.log(changes!.answer);
+```
+
+## Cancelling a session
+
+`cancelSession` asks the platform to interrupt the run. The response confirms
+that the request was accepted; the session may still report `pending` or
+`running` briefly while the worker stops. Poll status until it reaches a
+terminal state such as `interrupted`.
+
+```ts
+await cancelSession({ ...config, path: { id: sessionId } });
+
+let cancelledStatus = "running";
+while (!terminal.has(cancelledStatus)) {
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  const { data } = await getSessionStatus({ ...config, path: { id: sessionId } });
+  cancelledStatus = data!.status;
+}
+
+console.log(cancelledStatus);
 ```


### PR DESCRIPTION
## Summary

- Add README guidance for `cancelSession`.
- Clarify that cancel is asynchronous: a successful response means the interrupt was accepted, not that the session has already stopped.
- Show polling status until a terminal state such as `interrupted`.

## Why

JS SDK QA found that a cancelled run can continue to report `pending` or `running` briefly and may only later move to `interrupted`. The README should set that expectation for external users.

## Verification

- `pnpm --filter hai-agents run typecheck`
- `pnpm --filter hai-agents run build`
- README scan for `cancelSession`, `pending`, `running`, and `interrupted`
