### PR TITLE
ci: add npm publish workflow (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Pack only, do not publish"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm -r run typecheck
+      - name: Build
+        run: pnpm --filter hai-agents run build
+      - name: Assert tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: packages/sdk
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(node -p "require('./package.json').version")
+          if [ "$tag" != "$pkg" ]; then
+            echo "tag v$tag does not match package.json version $pkg" >&2
+            exit 1
+          fi
+      - name: Publish (dry run)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        working-directory: packages/sdk
+        run: npm publish --dry-run
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        working-directory: packages/sdk
+        run: npm publish --provenance --access public
+
+  release:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body: "hai-agents ${{ github.ref_name }}"


### PR DESCRIPTION
## Summary
Adds `.github/workflows/publish.yml` so `packages/sdk` (**hai-agents**) can be published to npm. Now rebased on `main`, so the only change is the workflow (the `package.json` metadata and `0.1.0` version already landed via #44).

- **Tag push `v*`** → build + `npm publish --provenance --access public` via npm Trusted Publishing (OIDC, no token), in the `release` environment, then cut a GitHub Release with a simple title/body (no auto-generated PR list).
- **`workflow_dispatch`** → `npm publish --dry-run` by default; set `dry_run=false` to publish on demand.
- **Node 24** so npm ≥ 11.5.1 (required for OIDC trusted publishing).
- **Version guard**: on a `vX.Y.Z` tag, the tag must match `packages/sdk/package.json`.

## npm bootstrap (differs from PyPI — important)
npm has **no pending publisher**; the trusted-publisher config only appears after the package exists. So:
1. **First `0.1.0` publish is manual** from a maintainer machine (`npm publish --access public`), no provenance.
2. Then add a **Trusted Publisher** in npm package settings: org `hcompai`, repo `hai-agents-ts`, workflow `publish.yml`, environment `release`. Also create a `release` environment in repo settings.
3. From the next version on, push a `vX.Y.Z` tag and this workflow publishes tokenless via OIDC with provenance.