### PR TITLE
chore(sdk): sync to agent_platform@f394d16 (v0.4.0)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1717,7 +1717,7 @@
           "Agents"
         ],
         "summary": "Create Agent",
-        "description": "Create an agent. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.",
+        "description": "Create an agent..",
         "operationId": "create_agent_api_v2_agents_post",
         "security": [
           {
@@ -1729,7 +1729,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateAgent"
+                "$ref": "#/components/schemas/Agent"
               }
             }
           }
@@ -1740,7 +1740,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AgentRecord"
+                  "$ref": "#/components/schemas/Agent"
                 }
               }
             }
@@ -1809,8 +1809,8 @@
                     "enum": [
                       "created_at",
                       "-created_at",
-                      "agent_identifier",
-                      "-agent_identifier"
+                      "agent_name",
+                      "-agent_name"
                     ],
                     "type": "string"
                   }
@@ -1834,7 +1834,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Page_AgentRecord_"
+                  "$ref": "#/components/schemas/Page_Agent_"
                 }
               }
             }
@@ -1852,14 +1852,14 @@
         }
       }
     },
-    "/api/v2/agents/{agent_identifier}": {
+    "/api/v2/agents/{agent_name}": {
       "get": {
         "tags": [
           "Agents"
         ],
         "summary": "Get Agent",
         "description": "Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.",
-        "operationId": "get_agent_api_v2_agents__agent_identifier__get",
+        "operationId": "get_agent_api_v2_agents__agent_name__get",
         "security": [
           {
             "HTTPBearer": []
@@ -1867,12 +1867,12 @@
         ],
         "parameters": [
           {
-            "name": "agent_identifier",
+            "name": "agent_name",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Agent Identifier"
+              "title": "Agent Name"
             }
           }
         ],
@@ -1882,7 +1882,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AgentRecord"
+                  "$ref": "#/components/schemas/Agent"
                 }
               }
             }
@@ -1905,7 +1905,7 @@
         ],
         "summary": "Update Agent",
         "description": "Replace ``spec``. ``spec.name`` must match the URL identifier; renames are not supported.",
-        "operationId": "update_agent_api_v2_agents__agent_identifier__put",
+        "operationId": "update_agent_api_v2_agents__agent_name__put",
         "security": [
           {
             "HTTPBearer": []
@@ -1913,12 +1913,12 @@
         ],
         "parameters": [
           {
-            "name": "agent_identifier",
+            "name": "agent_name",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Agent Identifier"
+              "title": "Agent Name"
             }
           }
         ],
@@ -1927,7 +1927,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateAgent"
+                "$ref": "#/components/schemas/Agent"
               }
             }
           }
@@ -1938,7 +1938,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AgentRecord"
+                  "$ref": "#/components/schemas/Agent"
                 }
               }
             }
@@ -1961,7 +1961,7 @@
         ],
         "summary": "Delete Agent",
         "description": "Delete by identifier. Reserved rows: H employee only.",
-        "operationId": "delete_agent_api_v2_agents__agent_identifier__delete",
+        "operationId": "delete_agent_api_v2_agents__agent_name__delete",
         "security": [
           {
             "HTTPBearer": []
@@ -1969,12 +1969,12 @@
         ],
         "parameters": [
           {
-            "name": "agent_identifier",
+            "name": "agent_name",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Agent Identifier"
+              "title": "Agent Name"
             }
           }
         ],
@@ -2116,45 +2116,6 @@
         "title": "Agent",
         "description": "Declarative agent definition."
       },
-      "AgentRecord": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "spec": {
-            "$ref": "#/components/schemas/Agent",
-            "description": "Typed agent definition consumed by the runtime."
-          },
-          "reserved": {
-            "type": "boolean",
-            "title": "Reserved",
-            "description": "True for H-owned rows; world-readable, write-locked behind employee_only."
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "id",
-          "spec",
-          "reserved",
-          "created_at",
-          "updated_at"
-        ],
-        "title": "AgentRecord",
-        "description": "Catalog row exposing an ``Agent`` spec payload plus AgP metadata.\n\nThe catalog handle is ``spec.name``; callers reference it directly\nvia ``record.spec.name`` rather than a duplicated top-level field."
-      },
       "Browser": {
         "properties": {
           "id": {
@@ -2210,27 +2171,6 @@
         ],
         "title": "Browser",
         "description": "Browser environment."
-      },
-      "CreateAgent": {
-        "properties": {
-          "spec": {
-            "$ref": "#/components/schemas/Agent",
-            "description": "Typed agent definition consumed by the runtime."
-          },
-          "reserved": {
-            "type": "boolean",
-            "title": "Reserved",
-            "description": "H employees only; rejected with 403 otherwise.",
-            "default": false
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "spec"
-        ],
-        "title": "CreateAgent",
-        "description": "``POST /api/v2/agents`` body."
       },
       "CreateEnvironment": {
         "properties": {
@@ -2606,11 +2546,11 @@
         "title": "ModelUsage",
         "description": "Per-model token usage."
       },
-      "Page_AgentRecord_": {
+      "Page_Agent_": {
         "properties": {
           "items": {
             "items": {
-              "$ref": "#/components/schemas/AgentRecord"
+              "$ref": "#/components/schemas/Agent"
             },
             "type": "array",
             "title": "Items"
@@ -2630,7 +2570,7 @@
           "total",
           "page"
         ],
-        "title": "Page[AgentRecord]"
+        "title": "Page[Agent]"
       },
       "Page_EnvironmentRecord_": {
         "properties": {
@@ -2831,8 +2771,7 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Agent",
-                "description": "Typed agent definition consumed by the runtime."
+                "$ref": "#/components/schemas/Agent"
               }
             ],
             "title": "Agent",
@@ -3315,21 +3254,6 @@
         ],
         "title": "TrajectoryStatus",
         "description": "State of a session/trajectory.\n\nLifecycle::\n\n    PENDING \u2192 RUNNING \u2192 {COMPLETED, FAILED, TIMED_OUT, INTERRUPTED}\n       |        \u2191  \u2191\n       |        |  \u2514\u2500\u2500\u2500\u2500\u2500\u2192 IDLE (interactive: agent waiting for next task)\n       |        \u2193\n       \u2514\u2500\u2500\u2500\u2500\u2500\u2192 PAUSED"
-      },
-      "UpdateAgent": {
-        "properties": {
-          "spec": {
-            "$ref": "#/components/schemas/Agent",
-            "description": "Typed agent definition consumed by the runtime."
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "spec"
-        ],
-        "title": "UpdateAgent",
-        "description": "``PUT /api/v2/agents/{agent_identifier}`` body. Full replace; ``spec.name`` is immutable."
       },
       "UpdateEnvironment": {
         "properties": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TypeScript SDK for H Company's agent API",
   "type": "module",
   "license": "MIT",

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -37,7 +37,6 @@ export {
 } from "./sdk.gen";
 export type {
   Agent,
-  AgentRecord,
   Browser,
   CancelSessionData,
   CancelSessionError,
@@ -45,7 +44,6 @@ export type {
   CancelSessionResponse,
   CancelSessionResponses,
   ClientOptions,
-  CreateAgent,
   CreateAgentData,
   CreateAgentError,
   CreateAgentErrors,
@@ -157,7 +155,7 @@ export type {
   Metrics,
   ModelCost,
   ModelUsage,
-  PageAgentRecord,
+  PageAgent,
   PageEnvironmentRecord,
   PageSessionSummary,
   PageSkillRecord,
@@ -205,7 +203,6 @@ export type {
   UnshareSessionErrors,
   UnshareSessionResponse,
   UnshareSessionResponses,
-  UpdateAgent,
   UpdateAgentData,
   UpdateAgentError,
   UpdateAgentErrors,

--- a/packages/sdk/src/client/sdk.gen.ts
+++ b/packages/sdk/src/client/sdk.gen.ts
@@ -661,7 +661,7 @@ export const listAgents = <ThrowOnError extends boolean = false>(
 /**
  * Create Agent
  *
- * Create an agent. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+ * Create an agent..
  */
 export const createAgent = <ThrowOnError extends boolean = false>(
   options: Options<CreateAgentData, ThrowOnError>,
@@ -694,7 +694,7 @@ export const deleteAgent = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/api/v2/agents/{agent_identifier}",
+    url: "/api/v2/agents/{agent_name}",
     ...options,
   });
 
@@ -712,7 +712,7 @@ export const getAgent = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/api/v2/agents/{agent_identifier}",
+    url: "/api/v2/agents/{agent_name}",
     ...options,
   });
 
@@ -730,7 +730,7 @@ export const updateAgent = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/api/v2/agents/{agent_identifier}",
+    url: "/api/v2/agents/{agent_name}",
     ...options,
     headers: {
       "Content-Type": "application/json",

--- a/packages/sdk/src/client/types.gen.ts
+++ b/packages/sdk/src/client/types.gen.ts
@@ -60,39 +60,6 @@ export type Agent = {
 };
 
 /**
- * AgentRecord
- *
- * Catalog row exposing an ``Agent`` spec payload plus AgP metadata.
- *
- * The catalog handle is ``spec.name``; callers reference it directly
- * via ``record.spec.name`` rather than a duplicated top-level field.
- */
-export type AgentRecord = {
-  /**
-   * Id
-   */
-  id: string;
-  /**
-   * Typed agent definition consumed by the runtime.
-   */
-  spec: Agent;
-  /**
-   * Reserved
-   *
-   * True for H-owned rows; world-readable, write-locked behind employee_only.
-   */
-  reserved: boolean;
-  /**
-   * Created At
-   */
-  created_at: string;
-  /**
-   * Updated At
-   */
-  updated_at: string;
-};
-
-/**
  * Browser
  *
  * Browser environment.
@@ -132,24 +99,6 @@ export type Browser = {
    * Initial URL.
    */
   start_url: string | null;
-};
-
-/**
- * CreateAgent
- *
- * ``POST /api/v2/agents`` body.
- */
-export type CreateAgent = {
-  /**
-   * Typed agent definition consumed by the runtime.
-   */
-  spec: Agent;
-  /**
-   * Reserved
-   *
-   * H employees only; rejected with 403 otherwise.
-   */
-  reserved?: boolean;
 };
 
 /**
@@ -390,13 +339,13 @@ export type ModelUsage = {
 };
 
 /**
- * Page[AgentRecord]
+ * Page[Agent]
  */
-export type PageAgentRecord = {
+export type PageAgent = {
   /**
    * Items
    */
-  items: Array<AgentRecord>;
+  items: Array<Agent>;
   /**
    * Total
    */
@@ -850,18 +799,6 @@ export type TrajectoryStatus =
   | "failed"
   | "timed_out"
   | "interrupted";
-
-/**
- * UpdateAgent
- *
- * ``PUT /api/v2/agents/{agent_identifier}`` body. Full replace; ``spec.name`` is immutable.
- */
-export type UpdateAgent = {
-  /**
-   * Typed agent definition consumed by the runtime.
-   */
-  spec: Agent;
-};
 
 /**
  * UpdateEnvironment
@@ -1948,7 +1885,7 @@ export type ListAgentsData = {
      * Sort by field
      */
     sort?: Array<
-      "created_at" | "-created_at" | "agent_identifier" | "-agent_identifier"
+      "created_at" | "-created_at" | "agent_name" | "-agent_name"
     > | null;
   };
   url: "/api/v2/agents";
@@ -1967,13 +1904,13 @@ export type ListAgentsResponses = {
   /**
    * Successful Response
    */
-  200: PageAgentRecord;
+  200: PageAgent;
 };
 
 export type ListAgentsResponse = ListAgentsResponses[keyof ListAgentsResponses];
 
 export type CreateAgentData = {
-  body: CreateAgent;
+  body: Agent;
   path?: never;
   query?: never;
   url: "/api/v2/agents";
@@ -1992,7 +1929,7 @@ export type CreateAgentResponses = {
   /**
    * Successful Response
    */
-  201: AgentRecord;
+  201: Agent;
 };
 
 export type CreateAgentResponse =
@@ -2002,12 +1939,12 @@ export type DeleteAgentData = {
   body?: never;
   path: {
     /**
-     * Agent Identifier
+     * Agent Name
      */
-    agent_identifier: string;
+    agent_name: string;
   };
   query?: never;
-  url: "/api/v2/agents/{agent_identifier}";
+  url: "/api/v2/agents/{agent_name}";
 };
 
 export type DeleteAgentErrors = {
@@ -2033,12 +1970,12 @@ export type GetAgentData = {
   body?: never;
   path: {
     /**
-     * Agent Identifier
+     * Agent Name
      */
-    agent_identifier: string;
+    agent_name: string;
   };
   query?: never;
-  url: "/api/v2/agents/{agent_identifier}";
+  url: "/api/v2/agents/{agent_name}";
 };
 
 export type GetAgentErrors = {
@@ -2054,21 +1991,21 @@ export type GetAgentResponses = {
   /**
    * Successful Response
    */
-  200: AgentRecord;
+  200: Agent;
 };
 
 export type GetAgentResponse = GetAgentResponses[keyof GetAgentResponses];
 
 export type UpdateAgentData = {
-  body: UpdateAgent;
+  body: Agent;
   path: {
     /**
-     * Agent Identifier
+     * Agent Name
      */
-    agent_identifier: string;
+    agent_name: string;
   };
   query?: never;
-  url: "/api/v2/agents/{agent_identifier}";
+  url: "/api/v2/agents/{agent_name}";
 };
 
 export type UpdateAgentErrors = {
@@ -2084,7 +2021,7 @@ export type UpdateAgentResponses = {
   /**
    * Successful Response
    */
-  200: AgentRecord;
+  200: Agent;
 };
 
 export type UpdateAgentResponse =


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.4.0` (minor — breaking upstream change)
**Upstream:** agent_platform@f394d16
