### PR TITLE
docs: include idle in session polling example

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -49,7 +49,7 @@ const { data: session } = await createSession({
 const sessionId = session!.id;
 
 // Poll until the session reaches a terminal state.
-const terminal = new Set(["completed", "failed", "timed_out", "interrupted"]);
+const terminal = new Set(["idle", "completed", "failed", "timed_out", "interrupted"]);
 let status = session!.status.status;
 while (!terminal.has(status)) {
   await new Promise((resolve) => setTimeout(resolve, 5000));


### PR DESCRIPTION
## Summary
- Add `idle` to the README polling status set so the example stops when a session is waiting for more input after an answer.

## Verification
- `pnpm --filter hai-agents run typecheck`
- `pnpm --filter hai-agents run build`