### PR TITLE
docs: include idle in session polling example

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -48,10 +48,10 @@ const { data: session } = await createSession({
 
 const sessionId = session!.id;
 
-// Poll until the session reaches a terminal state.
-const terminal = new Set(["completed", "failed", "timed_out", "interrupted"]);
+// Poll until the session finishes or waits for the next message.
+const doneOrWaiting = new Set(["idle", "completed", "failed", "timed_out", "interrupted"]);
 let status = session!.status.status;
-while (!terminal.has(status)) {
+while (!doneOrWaiting.has(status)) {
   await new Promise((resolve) => setTimeout(resolve, 5000));
   const { data } = await getSessionStatus({ ...config, path: { id: sessionId } });
   status = data!.status;


### PR DESCRIPTION
## Summary
- Add `idle` to the README polling stop conditions.
- Rename the example set from `terminal` to `doneOrWaiting` and clarify that `idle` means the session is waiting for the next message, not terminal.

## Why
During SDK QA, a live remote `h/web` session returned `idle` after producing an answer. `idle` is part of the generated `TrajectoryStatus` union, but the README polling example only stopped for `completed`, `failed`, `timed_out`, and `interrupted`.

That means a user copying the README sample can keep polling even after the current turn is done and the answer is available via `getSessionChanges`.

Current README snippet:

```ts
// Poll until the session reaches a terminal state.
const terminal = new Set(["completed", "failed", "timed_out", "interrupted"]);
let status = session!.status.status;
while (!terminal.has(status)) {
  await new Promise((resolve) => setTimeout(resolve, 5000));
  const { data } = await getSessionStatus({ ...config, path: { id: sessionId } });
  status = data!.status;
}
```

Generated status type includes `idle`:

```ts
export type TrajectoryStatus =
  | "pending"
  | "running"
  | "idle"
  | "completed"
  | "failed"
  | "timed_out"
  | "interrupted";
```

Updated README snippet:

```ts
// Poll until the session finishes or waits for the next message.
const doneOrWaiting = new Set(["idle", "completed", "failed", "timed_out", "interrupted"]);
let status = session!.status.status;
while (!doneOrWaiting.has(status)) {
  await new Promise((resolve) => setTimeout(resolve, 5000));
  const { data } = await getSessionStatus({ ...config, path: { id: sessionId } });
  status = data!.status;
}
```

## Verification
- `pnpm --filter hai-agents run typecheck`
- `pnpm --filter hai-agents run build`

Supersedes #27 after renaming the branch to remove the `codex/` prefix.