### PR TITLE
chore(sdk): sync to agent_platform@088b35d (v0.6.4)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2617,6 +2617,10 @@
           "status": {
             "$ref": "#/components/schemas/SessionStatus"
           },
+          "latest_answer": {
+            "title": "Latest Answer",
+            "description": "The agent's most recent final answer: free-form text, or structured data when the agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the changes endpoint, surfaced here for non-interactive runs."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "TypeScript SDK for H Company's agent API",
   "type": "module",
   "license": "MIT",

--- a/packages/sdk/src/client/types.gen.ts
+++ b/packages/sdk/src/client/types.gen.ts
@@ -403,6 +403,12 @@ export type Session = {
   request: SessionRequest;
   status: SessionStatus;
   /**
+   * Latest Answer
+   *
+   * The agent's most recent final answer: free-form text, or structured data when the agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the changes endpoint, surfaced here for non-interactive runs.
+   */
+  latest_answer?: unknown;
+  /**
    * Created At
    */
   created_at: string;


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.6.4` (patch — additive change)
**Upstream:** agent_platform@088b35d
