### PR TITLE
chore(sdk): reset version to 0.1.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.7.0",
+  "version": "0.1.0",
   "description": "TypeScript SDK for H Company's agent API",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Syncs the TypeScript SDK version with `hai-agents-python` at `0.1.0` for the first public release. Resets `0.7.0` (auto-bumped by the sync bot, never published).

The codegen bump logic reads the mirror's current version and increments, so future syncs continue from `0.1.0`.

Made with [Cursor](https://cursor.com)