### PR TITLE
chore: pre-release packaging cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  TypeScript SDK for <a href="https://hcompany.ai">H Company's Agent API</a>. Launch autonomous agents that browse the web and use tools, stream their progress, and steer them mid-run. Fully typed, with first-class ESM and CommonJS support.
+  TypeScript SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">
@@ -21,6 +21,8 @@
   <a href="https://portal.hcompany.ai">Get an API key</a>
   &nbsp;·&nbsp;
   <a href="https://www.npmjs.com/package/hai-agents">npm</a>
+  &nbsp;·&nbsp;
+  <a href="https://hcompany.ai">H Company</a>
 </p>
 
 ## Install
@@ -152,8 +154,8 @@ console.log(`limit: ${MAX_REQUEST_BYTES} bytes`);
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api) — guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai) — manage API keys and usage
+- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
+- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
 - [H Company](https://hcompany.ai)
 
 ## License

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  TypeScript SDK for <a href="https://hcompany.ai">H Company's Agent API</a>. Launch autonomous agents that browse the web and use tools, stream their progress, and steer them mid-run. Fully typed, with first-class ESM and CommonJS support.
+  TypeScript SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">
@@ -21,6 +21,8 @@
   <a href="https://portal.hcompany.ai">Get an API key</a>
   &nbsp;·&nbsp;
   <a href="https://www.npmjs.com/package/hai-agents">npm</a>
+  &nbsp;·&nbsp;
+  <a href="https://hcompany.ai">H Company</a>
 </p>
 
 ## Install
@@ -152,8 +154,8 @@ console.log(`limit: ${MAX_REQUEST_BYTES} bytes`);
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api) — guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai) — manage API keys and usage
+- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
+- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
 - [H Company](https://hcompany.ai)
 
 ## License

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,26 @@
 {
   "name": "hai-agents",
   "version": "0.1.0",
-  "description": "TypeScript SDK for H Company's agent API",
+  "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
+  "keywords": [
+    "agent",
+    "agents",
+    "computer-use",
+    "browser-use",
+    "llm",
+    "sdk",
+    "h-company"
+  ],
+  "homepage": "https://hub.hcompany.ai/agent-api",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hcompai/hai-agents-ts.git",
+    "directory": "packages/sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/hcompai/hai-agents-ts/issues"
+  },
+  "author": "H Company <contact@hcompany.ai>",
   "type": "module",
   "license": "MIT",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- **npm metadata**: add `keywords`, `homepage` (Agent API docs), `repository` (with `directory: packages/sdk`), `bugs`, and `author` so the npm page links back to the repo, docs, and issues.
- **README**: tighten the hero ("autonomous agents powered by Holo", no longer web-only) and add an `H Company` link to the nav. Mirrored to the repo root.

No internal comments to strip here (the hand-written TS config files were already comment-clean).

Made with [Cursor](https://cursor.com)