### PR TITLE
docs: trim README to essentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="https://hcompany.ai">H Company</a>
 </p>
 
-## Install
+## Installation
 
 ```bash
 npm install hai-agents
@@ -35,9 +35,7 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own
-browser, and describe the task in plain language. `runSessionUntilDone` polls
-until the agent reaches a terminal state and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
@@ -55,108 +53,15 @@ console.log(result.status); // "completed"
 console.log(result.answer);
 ```
 
-Tune the run with `timeoutMs`, `pollBackoffMs`, and `includeEvents`.
-
-## Create a session and poll it yourself
-
-For finer control, create the session and read it directly. `getSessionStatus`
-is a lightweight liveness check; the final `answer` lands in `getSessionChanges`.
-
-```ts
-const session = await client.sessions.createSession({
-  body: {
-    agent: "h/web-surfer-holo3-1-35b",
-    messages: "What are the top 3 stories on Hacker News right now?",
-  },
-});
-
-const status = await client.sessions.getSessionStatus({ id: session.id });
-console.log(status.status, status.steps);
-
-const changes = await client.sessions.getSessionChanges({ id: session.id, fromIndex: 0 });
-console.log(changes.answer);
-```
-
-## Steer a running session
-
-Send a message to redirect the agent mid-run, or record feedback once it finishes.
-
-```ts
-await client.sessions.sendSessionMessages({
-  id: session.id,
-  body: { type: "user_message", message: "Only consider stories posted in the last 24 hours." },
-});
-
-await client.sessions.submitSessionFeedback({
-  id: session.id,
-  body: { success: true, message: "The answer matched the front page." },
-});
-```
-
-`cancelSession` asks the platform to interrupt the run. The session may still
-report `running` briefly while the worker stops; poll until it reaches a terminal
-state such as `interrupted`.
-
-```ts
-await client.sessions.cancelSession({ id: session.id });
-```
-
-## Error handling
-
-Operations reject with `HaiAgentsError` on a non-2xx response. Inspect
-`statusCode` and `body`; there is no `{ data, error }` tuple to unwrap.
-
-```ts
-import { HaiAgentsError } from "hai-agents";
-
-try {
-  const session = await client.sessions.getSession({ id });
-  console.log(session.status);
-} catch (err) {
-  if (err instanceof HaiAgentsError) {
-    console.error(err.statusCode, err.message, err.body);
-  }
-  throw err;
-}
-```
-
-## Regions
-
-The client targets the EU region by default. Select a region with `environment`,
-or point at a custom URL with `baseUrl`.
-
-```ts
-import { HaiAgentsClient, HaiAgentsEnvironment } from "hai-agents";
-
-const usClient = new HaiAgentsClient({
-  token: process.env.H_API_KEY,
-  environment: HaiAgentsEnvironment.Us,
-});
-
-const proxied = new HaiAgentsClient({
-  token: process.env.H_API_KEY,
-  baseUrl: "https://my-proxy.example.com",
-});
-```
-
-## Request size limit
-
-The platform rejects request bodies above 5MB. `runSessionUntilDone` enforces
-this on the create payload; for ad-hoc requests, validate first to fail fast with
-a clear message instead of a server error.
-
-```ts
-import { assertRequestUnderLimit, MAX_REQUEST_BYTES } from "hai-agents";
-
-assertRequestUnderLimit({ body: { agent: "h/web-surfer-holo3-1-35b", messages } });
-console.log(`limit: ${MAX_REQUEST_BYTES} bytes`);
-```
+Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
-- [H Company](https://hcompany.ai)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
+
+- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
+- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
+- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  TypeScript SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
+  TypeScript SDK for the <a href="https://hcompany.ai">H Company</a> <a href="https://hub.hcompany.ai/agent-api">Agent API</a>. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -35,18 +35,16 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
 
 const client = new HaiAgentsClient({ token: process.env.H_API_KEY });
 
-const { items: agents } = await client.agents.listAgents();
-
 const result = await runSessionUntilDone(client, {
   body: {
-    agent: agents[0].name,
+    agent: "h/web-surfer-holo3-1-35b",
     messages: "What are the top 3 stories on Hacker News right now?",
   },
 });

--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
+List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
 
 const client = new HaiAgentsClient({ token: process.env.H_API_KEY });
 
+const { items: agents } = await client.agents.listAgents();
+
 const result = await runSessionUntilDone(client, {
   body: {
-    agent: "h/web-surfer-holo3-1-35b",
+    agent: agents[0].name,
     messages: "What are the top 3 stories on Hacker News right now?",
   },
 });

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
   &nbsp;·&nbsp;
   <a href="https://www.npmjs.com/package/hai-agents">npm</a>
   &nbsp;·&nbsp;
+  <a href="https://github.com/hcompai/hai-agents-python">Python SDK</a>
+  &nbsp;·&nbsp;
   <a href="https://hcompany.ai">H Company</a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -55,15 +55,9 @@ console.log(result.status); // "completed"
 console.log(result.answer);
 ```
 
-Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
-
 ## Documentation
 
-Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
-
-- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
-- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
-- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**, covering streaming progress, steering a live session, regions, structured output, and error handling.
 
 ## License
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -25,7 +25,7 @@
   <a href="https://hcompany.ai">H Company</a>
 </p>
 
-## Install
+## Installation
 
 ```bash
 npm install hai-agents
@@ -35,9 +35,7 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own
-browser, and describe the task in plain language. `runSessionUntilDone` polls
-until the agent reaches a terminal state and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
@@ -55,108 +53,15 @@ console.log(result.status); // "completed"
 console.log(result.answer);
 ```
 
-Tune the run with `timeoutMs`, `pollBackoffMs`, and `includeEvents`.
-
-## Create a session and poll it yourself
-
-For finer control, create the session and read it directly. `getSessionStatus`
-is a lightweight liveness check; the final `answer` lands in `getSessionChanges`.
-
-```ts
-const session = await client.sessions.createSession({
-  body: {
-    agent: "h/web-surfer-holo3-1-35b",
-    messages: "What are the top 3 stories on Hacker News right now?",
-  },
-});
-
-const status = await client.sessions.getSessionStatus({ id: session.id });
-console.log(status.status, status.steps);
-
-const changes = await client.sessions.getSessionChanges({ id: session.id, fromIndex: 0 });
-console.log(changes.answer);
-```
-
-## Steer a running session
-
-Send a message to redirect the agent mid-run, or record feedback once it finishes.
-
-```ts
-await client.sessions.sendSessionMessages({
-  id: session.id,
-  body: { type: "user_message", message: "Only consider stories posted in the last 24 hours." },
-});
-
-await client.sessions.submitSessionFeedback({
-  id: session.id,
-  body: { success: true, message: "The answer matched the front page." },
-});
-```
-
-`cancelSession` asks the platform to interrupt the run. The session may still
-report `running` briefly while the worker stops; poll until it reaches a terminal
-state such as `interrupted`.
-
-```ts
-await client.sessions.cancelSession({ id: session.id });
-```
-
-## Error handling
-
-Operations reject with `HaiAgentsError` on a non-2xx response. Inspect
-`statusCode` and `body`; there is no `{ data, error }` tuple to unwrap.
-
-```ts
-import { HaiAgentsError } from "hai-agents";
-
-try {
-  const session = await client.sessions.getSession({ id });
-  console.log(session.status);
-} catch (err) {
-  if (err instanceof HaiAgentsError) {
-    console.error(err.statusCode, err.message, err.body);
-  }
-  throw err;
-}
-```
-
-## Regions
-
-The client targets the EU region by default. Select a region with `environment`,
-or point at a custom URL with `baseUrl`.
-
-```ts
-import { HaiAgentsClient, HaiAgentsEnvironment } from "hai-agents";
-
-const usClient = new HaiAgentsClient({
-  token: process.env.H_API_KEY,
-  environment: HaiAgentsEnvironment.Us,
-});
-
-const proxied = new HaiAgentsClient({
-  token: process.env.H_API_KEY,
-  baseUrl: "https://my-proxy.example.com",
-});
-```
-
-## Request size limit
-
-The platform rejects request bodies above 5MB. `runSessionUntilDone` enforces
-this on the create payload; for ad-hoc requests, validate first to fail fast with
-a clear message instead of a server error.
-
-```ts
-import { assertRequestUnderLimit, MAX_REQUEST_BYTES } from "hai-agents";
-
-assertRequestUnderLimit({ body: { agent: "h/web-surfer-holo3-1-35b", messages } });
-console.log(`limit: ${MAX_REQUEST_BYTES} bytes`);
-```
+Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
-- [H Company](https://hcompany.ai)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
+
+- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
+- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
+- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
 
 ## License
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  TypeScript SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
+  TypeScript SDK for the <a href="https://hcompany.ai">H Company</a> <a href="https://hub.hcompany.ai/agent-api">Agent API</a>. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,18 +35,16 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
 
 const client = new HaiAgentsClient({ token: process.env.H_API_KEY });
 
-const { items: agents } = await client.agents.listAgents();
-
 const result = await runSessionUntilDone(client, {
   body: {
-    agent: agents[0].name,
+    agent: "h/web-surfer-holo3-1-35b",
     messages: "What are the top 3 stories on Hacker News right now?",
   },
 });

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,16 +35,18 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
+List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
 
 const client = new HaiAgentsClient({ token: process.env.H_API_KEY });
 
+const { items: agents } = await client.agents.listAgents();
+
 const result = await runSessionUntilDone(client, {
   body: {
-    agent: "h/web-surfer-holo3-1-35b",
+    agent: agents[0].name,
     messages: "What are the top 3 stories on Hacker News right now?",
   },
 });

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -22,6 +22,8 @@
   &nbsp;·&nbsp;
   <a href="https://www.npmjs.com/package/hai-agents">npm</a>
   &nbsp;·&nbsp;
+  <a href="https://github.com/hcompai/hai-agents-python">Python SDK</a>
+  &nbsp;·&nbsp;
   <a href="https://hcompany.ai">H Company</a>
 </p>
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -55,15 +55,9 @@ console.log(result.status); // "completed"
 console.log(result.answer);
 ```
 
-Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
-
 ## Documentation
 
-Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
-
-- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
-- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
-- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**, covering streaming progress, steering a live session, regions, structured output, and error handling.
 
 ## License
 


### PR DESCRIPTION
## Summary
Pares the README down to the essentials, in the spirit of the OpenAI and Anthropic SDK READMEs.

- Keeps the banner, badges, tagline, and nav row.
- One **Install** + one **Quickstart**.
- New **Documentation** section points dynamically to the hub with a few deep links, instead of inlining steering / regions / error handling / request-limit / manual-polling sections (all already on the hub).

Applied to both the root README (GitHub homepage) and `packages/sdk/README.md` (npm).

Made with [Cursor](https://cursor.com)