### PR TITLE
chore(sdk): sync to agent_platform@d292cb0 (v0.1.1)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2221,7 +2221,7 @@
             },
             "type": "array",
             "title": "Environments",
-            "description": "Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind."
+            "description": "Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none)."
           },
           "model": {
             "anyOf": [
@@ -2944,6 +2944,18 @@
             ],
             "title": "Answer Format",
             "description": "JSON Schema the final answer must conform to. Null returns a free-form text answer."
+          },
+          "agent_artifact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Artifact",
+            "description": "Target version of the agent artifact to use."
           }
         },
         "type": "object",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/api/types/Agent.ts
+++ b/packages/sdk/src/client/api/types/Agent.ts
@@ -10,7 +10,7 @@ export interface Agent {
     name: string;
     /** What the agent does. Parent agents read this to decide when to delegate to it. */
     description: string;
-    /** Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind. */
+    /** Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none). */
     environments: HaiAgents.AgentEnvironmentsItem[];
     /** Model that serves the agent. Defaults to the platform model if omitted. */
     model?: string | null;

--- a/packages/sdk/src/client/api/types/SessionRequest.ts
+++ b/packages/sdk/src/client/api/types/SessionRequest.ts
@@ -22,4 +22,6 @@ export interface SessionRequest {
     parentSessionId?: string | null;
     /** JSON Schema the final answer must conform to. Null returns a free-form text answer. */
     answerFormat?: Record<string, unknown> | null;
+    /** Target version of the agent artifact to use. */
+    agentArtifact?: string | null;
 }

--- a/packages/sdk/src/client/serialization/types/SessionRequest.ts
+++ b/packages/sdk/src/client/serialization/types/SessionRequest.ts
@@ -22,6 +22,7 @@ export const SessionRequest: core.serialization.ObjectSchema<serializers.Session
             "answer_format",
             core.serialization.record(core.serialization.string(), core.serialization.unknown()).optionalNullable(),
         ),
+        agentArtifact: core.serialization.property("agent_artifact", core.serialization.string().optionalNullable()),
     });
 
 export declare namespace SessionRequest {
@@ -34,5 +35,6 @@ export declare namespace SessionRequest {
         group_id?: (string | null | undefined) | null;
         parent_session_id?: (string | null | undefined) | null;
         answer_format?: (Record<string, unknown> | null | undefined) | null;
+        agent_artifact?: (string | null | undefined) | null;
     }
 }


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.1` (patch — additive change)
**Upstream:** agent_platform@d292cb0
