### PR TITLE
chore(sdk): sync to agent_platform@35efd9b (v0.2.0)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/Client.ts
+++ b/packages/sdk/src/client/Client.ts
@@ -21,7 +21,7 @@ export class HaiAgentsClient {
     protected _environments: EnvironmentsClient | undefined;
     protected _agents: AgentsClient | undefined;
 
-    constructor(options: HaiAgentsClient.Options) {
+    constructor(options: HaiAgentsClient.Options = {}) {
         this._options = normalizeClientOptionsWithAuth(options);
     }
 

--- a/packages/sdk/src/client/api/resources/agents/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/agents/client/Client.ts
@@ -20,7 +20,7 @@ export declare namespace AgentsClient {
 export class AgentsClient {
     protected readonly _options: NormalizedClientOptionsWithAuth<AgentsClient.Options>;
 
-    constructor(options: AgentsClient.Options) {
+    constructor(options: AgentsClient.Options = {}) {
         this._options = normalizeClientOptionsWithAuth(options);
     }
 

--- a/packages/sdk/src/client/api/resources/environments/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/environments/client/Client.ts
@@ -20,7 +20,7 @@ export declare namespace EnvironmentsClient {
 export class EnvironmentsClient {
     protected readonly _options: NormalizedClientOptionsWithAuth<EnvironmentsClient.Options>;
 
-    constructor(options: EnvironmentsClient.Options) {
+    constructor(options: EnvironmentsClient.Options = {}) {
         this._options = normalizeClientOptionsWithAuth(options);
     }
 

--- a/packages/sdk/src/client/api/resources/sessions/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/sessions/client/Client.ts
@@ -20,7 +20,7 @@ export declare namespace SessionsClient {
 export class SessionsClient {
     protected readonly _options: NormalizedClientOptionsWithAuth<SessionsClient.Options>;
 
-    constructor(options: SessionsClient.Options) {
+    constructor(options: SessionsClient.Options = {}) {
         this._options = normalizeClientOptionsWithAuth(options);
     }
 

--- a/packages/sdk/src/client/api/resources/skills/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/skills/client/Client.ts
@@ -20,7 +20,7 @@ export declare namespace SkillsClient {
 export class SkillsClient {
     protected readonly _options: NormalizedClientOptionsWithAuth<SkillsClient.Options>;
 
-    constructor(options: SkillsClient.Options) {
+    constructor(options: SkillsClient.Options = {}) {
         this._options = normalizeClientOptionsWithAuth(options);
     }
 

--- a/packages/sdk/src/client/auth/BearerAuthProvider.ts
+++ b/packages/sdk/src/client/auth/BearerAuthProvider.ts
@@ -3,7 +3,8 @@
 import * as core from "../core/index.js";
 import * as errors from "../errors/index.js";
 
-const TOKEN_PARAM = "token" as const;
+const TOKEN_PARAM = "apiKey" as const;
+const ENV_TOKEN = "H_API_KEY" as const;
 
 export class BearerAuthProvider implements core.AuthProvider {
     private readonly options: BearerAuthProvider.Options;
@@ -13,7 +14,7 @@ export class BearerAuthProvider implements core.AuthProvider {
     }
 
     public static canCreate(options: Partial<BearerAuthProvider.Options>): boolean {
-        return options?.[TOKEN_PARAM] != null;
+        return options?.[TOKEN_PARAM] != null || process.env?.[ENV_TOKEN] != null;
     }
 
     public async getAuthRequest({
@@ -21,15 +22,15 @@ export class BearerAuthProvider implements core.AuthProvider {
     }: {
         endpointMetadata?: core.EndpointMetadata;
     } = {}): Promise<core.AuthRequest> {
-        const token = await core.Supplier.get(this.options[TOKEN_PARAM]);
-        if (token == null) {
+        const apiKey = (await core.Supplier.get(this.options[TOKEN_PARAM])) ?? process.env?.[ENV_TOKEN];
+        if (apiKey == null) {
             throw new errors.HaiAgentsError({
                 message: BearerAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
             });
         }
 
         return {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: { Authorization: `Bearer ${apiKey}` },
         };
     }
 }
@@ -37,9 +38,9 @@ export class BearerAuthProvider implements core.AuthProvider {
 export namespace BearerAuthProvider {
     export const AUTH_SCHEME = "HTTPBearer" as const;
     export const AUTH_CONFIG_ERROR_MESSAGE: string =
-        `Please provide '${TOKEN_PARAM}' when initializing the client` as const;
+        `Please provide '${TOKEN_PARAM}' when initializing the client, or set the '${ENV_TOKEN}' environment variable` as const;
     export type Options = AuthOptions;
-    export type AuthOptions = { [TOKEN_PARAM]: core.Supplier<core.BearerToken> };
+    export type AuthOptions = { [TOKEN_PARAM]?: core.Supplier<core.BearerToken> | undefined };
 
     export function createInstance(options: Options): core.AuthProvider {
         return new BearerAuthProvider(options);


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.2.0` (minor — breaking upstream change)
**Upstream:** agent_platform@35efd9b
