### PR TITLE
chore(sdk): sync to agent_platform@7507738 (v0.2.1)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -10,11 +10,11 @@ export {
   TERMINAL_SESSION_STATUSES,
   assertRequestUnderLimit,
   isTerminalSessionStatus,
-  runSessionUntilDone,
+  runSession,
   waitForSession,
 } from "./polling.js";
 export type {
-  RunSessionUntilDoneOptions,
+  RunSessionOptions,
   SessionRunResult,
   WaitForSessionOptions,
 } from "./polling.js";

--- a/packages/sdk/src/client/polling.ts
+++ b/packages/sdk/src/client/polling.ts
@@ -38,7 +38,7 @@ export type WaitForSessionOptions = {
   maxPolls?: number;
 };
 
-export type RunSessionUntilDoneOptions = CreateSessionRequest & {
+export type RunSessionOptions = CreateSessionRequest & {
   waitForSeconds?: number;
   includeEvents?: boolean;
   timeoutMs?: number;
@@ -144,9 +144,9 @@ export async function waitForSession(
   throw new Error(`Session ${id} did not reach a terminal status before maxPolls=${maxPolls}`);
 }
 
-export async function runSessionUntilDone(
+export async function runSession(
   client: HaiAgentsClient,
-  options: RunSessionUntilDoneOptions,
+  options: RunSessionOptions,
 ): Promise<SessionRunResult> {
   const { waitForSeconds, includeEvents, timeoutMs, pollBackoffMs, maxPolls, ...createRequest } = options;
   assertRequestUnderLimit(createRequest);


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.2.1` (patch; every sync bumps +0.0.1) · upstream flagged this a breaking change
**Upstream:** agent_platform@7507738
