### PR TITLE
fix: README apiKey + runSession, reset version to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSession` polls until the agent finishes and returns the final answer.
 
 ```ts
-import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
+import { HaiAgentsClient, runSession } from "hai-agents";
 
-const client = new HaiAgentsClient({ token: process.env.H_API_KEY });
+const client = new HaiAgentsClient({ apiKey: process.env.H_API_KEY });
 
-const result = await runSessionUntilDone(client, {
+const result = await runSession(client, {
   body: {
     agent: "h/web-surfer-holo3-1-35b",
     messages: "What are the top 3 stories on Hacker News right now?",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@
 npm install hai-agents
 ```
 
-Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai).
+Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
+
+```bash
+export H_API_KEY=hk-...
+```
 
 ## Quickstart
 
@@ -42,7 +46,7 @@ Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own b
 ```ts
 import { HaiAgentsClient, runSession } from "hai-agents";
 
-const client = new HaiAgentsClient({ apiKey: process.env.H_API_KEY });
+const client = new HaiAgentsClient(); // reads H_API_KEY from the environment
 
 const result = await runSession(client, {
   body: {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -37,14 +37,14 @@ Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://po
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSessionUntilDone` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSession` polls until the agent finishes and returns the final answer.
 
 ```ts
-import { HaiAgentsClient, runSessionUntilDone } from "hai-agents";
+import { HaiAgentsClient, runSession } from "hai-agents";
 
-const client = new HaiAgentsClient({ token: process.env.H_API_KEY });
+const client = new HaiAgentsClient({ apiKey: process.env.H_API_KEY });
 
-const result = await runSessionUntilDone(client, {
+const result = await runSession(client, {
   body: {
     agent: "h/web-surfer-holo3-1-35b",
     messages: "What are the top 3 stories on Hacker News right now?",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -33,7 +33,11 @@
 npm install hai-agents
 ```
 
-Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai).
+Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
+
+```bash
+export H_API_KEY=hk-...
+```
 
 ## Quickstart
 
@@ -42,7 +46,7 @@ Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own b
 ```ts
 import { HaiAgentsClient, runSession } from "hai-agents";
 
-const client = new HaiAgentsClient({ apiKey: process.env.H_API_KEY });
+const client = new HaiAgentsClient(); // reads H_API_KEY from the environment
 
 const result = await runSession(client, {
   body: {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.2.1",
+  "version": "0.1.2",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## What

- Update both READMEs to match the regenerated 0.2.1 client: `runSessionUntilDone` -> `runSession`, and construct a bare `new HaiAgentsClient()` after `export H_API_KEY=hk-...` (the client reads the env var) instead of passing `token:`.
- Reset `packages/sdk/package.json` version **0.2.1 -> 0.1.2**.

## Why

The sync regenerates only the client; the hand-written READMEs drifted (still `token:` / `runSessionUntilDone`).

Version: nothing past 0.1.1 is published on npm. `0.2.0`/`0.2.1` were artifacts of the old breaking->minor bump (before always-patch landed in agp). Resetting to 0.1.2 keeps Python and TS in lockstep on the always-patch line (0.1.1 -> 0.1.2 carries the api_key + run_session renames together). Pairs with hcompai/hai-agents-python#59.

Made with [Cursor](https://cursor.com)