### PR TITLE
ci: drop --provenance from npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Publish
         if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
         working-directory: packages/sdk
-        run: npm publish --provenance --access public
+        run: npm publish --access public
 
   release:
     needs: publish


### PR DESCRIPTION
`npm publish --provenance` requires a public source repository, but `hai-agents-ts` is internal, so npm rejects the publish with `422 ... Unsupported GitHub Actions source repository visibility: "internal"`. This blocks the 0.1.2 release.

Drop `--provenance`; `0.1.1` was already published without it, so this is no regression. We can re-add it if/when the repo goes public.

Made with [Cursor](https://cursor.com)