### PR TITLE
chore(sdk): sync to agent_platform@bb407a7 (v0.1.3)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -1,10 +1,11 @@
 export * as HaiAgents from "./api/index.js";
 export type { BaseClientOptions, BaseRequestOptions } from "./BaseClient.js";
-export { HaiAgentsClient } from "./Client.js";
+export { HaiAgentsClient } from "./oo.js";
 export { HaiAgentsEnvironment } from "./environments.js";
 export { HaiAgentsError, HaiAgentsTimeoutError } from "./errors/index.js";
 export * from "./exports.js";
 export * as serialization from "./serialization/index.js";
+export { SessionHandle } from "./polling.js";
 export {
   MAX_REQUEST_BYTES,
   TERMINAL_SESSION_STATUSES,
@@ -14,6 +15,7 @@ export {
   waitForSession,
 } from "./polling.js";
 export type {
+  CreateSessionParams,
   RunSessionOptions,
   SessionRunResult,
   WaitForSessionOptions,

--- a/packages/sdk/src/client/oo.ts
+++ b/packages/sdk/src/client/oo.ts
@@ -1,0 +1,39 @@
+import { HaiAgentsClient as FernClient } from "./Client.js";
+import {
+  SessionHandle,
+  assertRequestUnderLimit,
+  runSession,
+  toCreateRequest,
+  type CreateSessionParams,
+  type RunSessionOptions,
+  type SessionRunResult,
+} from "./polling.js";
+
+/**
+ * The public SDK client. Extends the Fern-generated client with create-and-run
+ * convenience methods (`runSession`, `startSession`, `session`) that delegate to
+ * the hand-written polling helpers.
+ */
+export class HaiAgentsClient extends FernClient {
+  /** Create a session and resolve once it completes, returning the result and final answer. */
+  public runSession(options: RunSessionOptions): Promise<SessionRunResult> {
+    return runSession(this, options);
+  }
+
+  /** Create a session and return a handle to it without waiting. */
+  public async startSession(params: CreateSessionParams): Promise<SessionHandle> {
+    assertRequestUnderLimit(params);
+    const session = await this.sessions.createSession(toCreateRequest(params));
+    return new SessionHandle(this, session.id);
+  }
+
+  /** Wrap an existing session id in a handle. */
+  public session(id: string): SessionHandle {
+    return new SessionHandle(this, id);
+  }
+}
+
+export namespace HaiAgentsClient {
+  export type Options = FernClient.Options;
+  export type RequestOptions = FernClient.RequestOptions;
+}

--- a/packages/sdk/src/client/polling.ts
+++ b/packages/sdk/src/client/polling.ts
@@ -1,6 +1,11 @@
 import type { HaiAgentsClient } from "./Client.js";
 import type {
   CreateSessionRequest,
+  GetSessionChangesRequest,
+  SendSessionMessagesRequest,
+  Session,
+  SessionRequest,
+  SessionStatus,
   TrajectoryChanges,
   TrajectoryEvent,
   TrajectoryStatus,
@@ -22,7 +27,20 @@ export type SessionRunResult = {
   events: TrajectoryEvent[];
   nextFromIndex: number;
   finalChanges?: TrajectoryChanges;
+  /** The session's final answer, if it produced one (shortcut for finalChanges.answer). */
+  answer?: TrajectoryChanges["answer"];
 };
+
+/** Flat create-session parameters: the request body fields plus the idempotency key. */
+export type CreateSessionParams = SessionRequest & {
+  idempotencyKey?: string | null;
+};
+
+/** Split flat params into the nested { idempotencyKey, body } shape the generated client expects. */
+export function toCreateRequest(params: CreateSessionParams): CreateSessionRequest {
+  const { idempotencyKey, ...body } = params;
+  return { idempotencyKey: idempotencyKey ?? undefined, body };
+}
 
 export type WaitForSessionOptions = {
   id: string;
@@ -38,7 +56,7 @@ export type WaitForSessionOptions = {
   maxPolls?: number;
 };
 
-export type RunSessionOptions = CreateSessionRequest & {
+export type RunSessionOptions = CreateSessionParams & {
   waitForSeconds?: number;
   includeEvents?: boolean;
   timeoutMs?: number;
@@ -130,7 +148,8 @@ export async function waitForSession(
 
     const { status } = await client.sessions.getSessionStatus({ id });
     if (isTerminalSessionStatus(status)) {
-      return { id, status, events, nextFromIndex, finalChanges: await finalChanges(client, id, lastChanges, limit) };
+      const changes = await finalChanges(client, id, lastChanges, limit);
+      return { id, status, events, nextFromIndex, finalChanges: changes, answer: changes?.answer };
     }
 
     // The long-poll above paces the loop when streaming events; otherwise sleep.
@@ -148,9 +167,9 @@ export async function runSession(
   client: HaiAgentsClient,
   options: RunSessionOptions,
 ): Promise<SessionRunResult> {
-  const { waitForSeconds, includeEvents, timeoutMs, pollBackoffMs, maxPolls, ...createRequest } = options;
-  assertRequestUnderLimit(createRequest);
-  const session = await client.sessions.createSession(createRequest);
+  const { waitForSeconds, includeEvents, timeoutMs, pollBackoffMs, maxPolls, ...createParams } = options;
+  assertRequestUnderLimit(createParams);
+  const session = await client.sessions.createSession(toCreateRequest(createParams));
   return waitForSession(client, {
     id: session.id,
     waitForSeconds,
@@ -159,4 +178,49 @@ export async function runSession(
     pollBackoffMs,
     maxPolls,
   });
+}
+
+/** A created session bound to its client: object-oriented sugar over the polling helpers. */
+export class SessionHandle {
+  constructor(
+    private readonly client: HaiAgentsClient,
+    public readonly id: string,
+  ) {}
+
+  get(): Promise<Session> {
+    return this.client.sessions.getSession({ id: this.id });
+  }
+
+  status(): Promise<SessionStatus> {
+    return this.client.sessions.getSessionStatus({ id: this.id });
+  }
+
+  changes(options?: Omit<GetSessionChangesRequest, "id">): Promise<TrajectoryChanges | undefined> {
+    return this.client.sessions.getSessionChanges({ id: this.id, ...options });
+  }
+
+  sendMessage(message: SendSessionMessagesRequest["body"]): Promise<void> {
+    return this.client.sessions.sendSessionMessages({ id: this.id, body: message });
+  }
+
+  pause(): Promise<void> {
+    return this.client.sessions.pauseSession({ id: this.id });
+  }
+
+  resume(): Promise<void> {
+    return this.client.sessions.resumeSession({ id: this.id });
+  }
+
+  cancel(): Promise<void> {
+    return this.client.sessions.cancelSession({ id: this.id });
+  }
+
+  forceAnswer(): Promise<void> {
+    return this.client.sessions.forceSessionAnswer({ id: this.id });
+  }
+
+  /** Block until the session reaches a terminal status; resolves with the result and final answer. */
+  waitForCompletion(options?: Omit<WaitForSessionOptions, "id">): Promise<SessionRunResult> {
+    return waitForSession(this.client, { id: this.id, ...options });
+  }
 }


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.3` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@bb407a7


---

**Note:** generated locally and opened by hand because the `generate-sdks` `ts-sdk` job kept failing on the Docker Hub unauthenticated pull-rate limit (`fernapi/fern-typescript-sdk:3.70.7` → `toomanyrequests`); the `python-sdk` job wins the pull race so its sync (#64) landed alone. Output is byte-for-byte the same `ts/generate.sh` against the same CI-exported schema; `tsc --noEmit` passes. Diff is just the OO surface: new `oo.ts` (`HaiAgentsClient.runSession`/`startSession`/`session`), expanded `polling.ts` (`SessionHandle` incl. `get`/`pause`/`resume`), and the `index.ts` re-exports.

Made with [Cursor](https://cursor.com)
