### PR TITLE
chore(sdk): sync to agent_platform@ac84bdd (v0.1.5)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2053,7 +2053,7 @@
           "Agents"
         ],
         "summary": "Get Agent",
-        "description": "Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.",
+        "description": "Fetch by identifier; 404 if not visible. ``resolve=true`` materialises spec leaves.",
         "operationId": "get_agent_api_v2_agents__agent_name__get",
         "security": [
           {
@@ -2069,6 +2069,18 @@
               "type": "string",
               "title": "Agent Name"
             }
+          },
+          {
+            "name": "resolve",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Materialise string environment/skill/subagent leaves into full specs.",
+              "default": false,
+              "title": "Resolve"
+            },
+            "description": "Materialise string environment/skill/subagent leaves into full specs."
           }
         ],
         "responses": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/api/resources/agents/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/agents/client/Client.ts
@@ -213,7 +213,7 @@ export class AgentsClient {
     }
 
     /**
-     * Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+     * Fetch by identifier; 404 if not visible. ``resolve=true`` materialises spec leaves.
      *
      * @param {HaiAgents.GetAgentRequest} request
      * @param {AgentsClient.RequestOptions} requestOptions - Request-specific configuration.
@@ -236,7 +236,10 @@ export class AgentsClient {
         request: HaiAgents.GetAgentRequest,
         requestOptions?: AgentsClient.RequestOptions,
     ): Promise<core.WithRawResponse<HaiAgents.Agent>> {
-        const { agentName } = request;
+        const { agentName, resolve } = request;
+        const _queryParams: Record<string, unknown> = {
+            resolve,
+        };
         const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
             _authRequest.headers,
@@ -252,7 +255,11 @@ export class AgentsClient {
             ),
             method: "GET",
             headers: _headers,
-            queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
+            queryString: core.url
+                .queryBuilder()
+                .addMany(_queryParams)
+                .mergeAdditional(requestOptions?.queryParams)
+                .build(),
             timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
             maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
             abortSignal: requestOptions?.abortSignal,

--- a/packages/sdk/src/client/api/resources/agents/client/requests/GetAgentRequest.ts
+++ b/packages/sdk/src/client/api/resources/agents/client/requests/GetAgentRequest.ts
@@ -8,4 +8,6 @@
  */
 export interface GetAgentRequest {
     agentName: string;
+    /** Materialise string environment/skill/subagent leaves into full specs. */
+    resolve?: boolean;
 }


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.5` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@ac84bdd
