### PR TITLE
chore(sdk): sync to agent_platform@557aa10 (v0.1.6)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -23,7 +23,7 @@
           "Sessions"
         ],
         "summary": "Create Session",
-        "description": "Create an agentic session.\n\nPass ``Idempotency-Key`` for safe retries: identical requests within 24h\nreturn the original session; reuse with a different body returns 422.",
+        "description": "Create an agentic session.",
         "operationId": "create_session_api_v2_sessions_post",
         "security": [
           {
@@ -1475,7 +1475,7 @@
           "Skills"
         ],
         "summary": "Delete Skill",
-        "description": "Delete by name. Reserved rows: H admin only.",
+        "description": "Delete by name. Reserved rows: H employee only.",
         "operationId": "delete_skill_api_v2_skills__name__delete",
         "security": [
           {
@@ -1835,7 +1835,7 @@
           "Environments"
         ],
         "summary": "Delete Environment",
-        "description": "Delete by identifier. Reserved rows: H admin only.",
+        "description": "Delete by identifier. Reserved rows: H employee only.",
         "operationId": "delete_environment_api_v2_environments__id__delete",
         "security": [
           {
@@ -2167,7 +2167,7 @@
           "Agents"
         ],
         "summary": "Delete Agent",
-        "description": "Delete by identifier. Reserved rows: H admin only.",
+        "description": "Delete by identifier. Reserved rows: H employee only.",
         "operationId": "delete_agent_api_v2_agents__agent_name__delete",
         "security": [
           {
@@ -2428,7 +2428,7 @@
           "page"
         ],
         "title": "EnvironmentPage",
-        "description": "Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name.\n\n``Environment`` is ``Annotated[Browser | CodeSandbox | MCP | Memory, Field(discriminator=\"kind\")]``\nand has no ``__name__``. Without this subclass, Pydantic titles ``Page[Environment]``\nby repr()ing the type parameter, producing a 95-char schema name that leaks\nPydantic FieldInfo into generated SDKs."
+        "description": "Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name."
       },
       "Feedback": {
         "properties": {
@@ -3110,7 +3110,7 @@
           "share_url"
         ],
         "title": "ShareLink",
-        "description": "Public share URL for a session.\n\n``share_url`` is a path; clients prepend the AgP host. Today this points at the\nv1 share router (``/share/api/v1/trajectories/{id}``); will migrate to\n``/share/v1/sessions/{id}`` once the v2 share router lands."
+        "description": "Public share URL for a session."
       },
       "Skill": {
         "properties": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/api/resources/agents/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/agents/client/Client.ts
@@ -403,7 +403,7 @@ export class AgentsClient {
     }
 
     /**
-     * Delete by identifier. Reserved rows: H admin only.
+     * Delete by identifier. Reserved rows: H employee only.
      *
      * @param {HaiAgents.DeleteAgentRequest} request
      * @param {AgentsClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/packages/sdk/src/client/api/resources/environments/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/environments/client/Client.ts
@@ -409,7 +409,7 @@ export class EnvironmentsClient {
     }
 
     /**
-     * Delete by identifier. Reserved rows: H admin only.
+     * Delete by identifier. Reserved rows: H employee only.
      *
      * @param {HaiAgents.DeleteEnvironmentRequest} request
      * @param {EnvironmentsClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/packages/sdk/src/client/api/resources/sessions/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/sessions/client/Client.ts
@@ -151,9 +151,6 @@ export class SessionsClient {
     /**
      * Create an agentic session.
      *
-     * Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
-     * return the original session; reuse with a different body returns 422.
-     *
      * @param {HaiAgents.CreateSessionRequest} request
      * @param {SessionsClient.RequestOptions} requestOptions - Request-specific configuration.
      *

--- a/packages/sdk/src/client/api/resources/skills/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/skills/client/Client.ts
@@ -396,7 +396,7 @@ export class SkillsClient {
     }
 
     /**
-     * Delete by name. Reserved rows: H admin only.
+     * Delete by name. Reserved rows: H employee only.
      *
      * @param {HaiAgents.DeleteSkillRequest} request
      * @param {SkillsClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/packages/sdk/src/client/api/types/EnvironmentPage.ts
+++ b/packages/sdk/src/client/api/types/EnvironmentPage.ts
@@ -4,11 +4,6 @@ import type * as HaiAgents from "../index.js";
 
 /**
  * Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name.
- *
- * ``Environment`` is ``Annotated[Browser | CodeSandbox | MCP | Memory, Field(discriminator="kind")]``
- * and has no ``__name__``. Without this subclass, Pydantic titles ``Page[Environment]``
- * by repr()ing the type parameter, producing a 95-char schema name that leaks
- * Pydantic FieldInfo into generated SDKs.
  */
 export interface EnvironmentPage {
     items: HaiAgents.Environment[];

--- a/packages/sdk/src/client/api/types/ShareLink.ts
+++ b/packages/sdk/src/client/api/types/ShareLink.ts
@@ -2,10 +2,6 @@
 
 /**
  * Public share URL for a session.
- *
- * ``share_url`` is a path; clients prepend the AgP host. Today this points at the
- * v1 share router (``/share/api/v1/trajectories/{id}``); will migrate to
- * ``/share/v1/sessions/{id}`` once the v2 share router lands.
  */
 export interface ShareLink {
     shareUrl: string;


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.6` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@557aa10
