### PR TITLE
chore(sdk): sync to agent_platform@f57ac85 (v0.1.6)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3156,6 +3156,18 @@
           "status": {
             "$ref": "#/components/schemas/SessionStatus"
           },
+          "agent_view_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent View Url",
+            "description": "URL of the session's Agent View page on the H Platform (live view and replay)."
+          },
           "latest_answer": {
             "title": "Latest Answer",
             "description": "The agent's most recent final answer: free-form text, or structured data when the agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the changes endpoint, surfaced here for non-interactive runs."
@@ -3394,6 +3406,18 @@
           },
           "status": {
             "$ref": "#/components/schemas/TrajectoryStatus"
+          },
+          "agent_view_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent View Url",
+            "description": "URL of the session's Agent View page on the H Platform (live view and replay)."
           },
           "first_message": {
             "anyOf": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/api/types/Session.ts
+++ b/packages/sdk/src/client/api/types/Session.ts
@@ -9,6 +9,8 @@ export interface Session {
     id: string;
     request: HaiAgents.SessionRequest;
     status: HaiAgents.SessionStatus;
+    /** URL of the session's Agent View page on the H Platform (live view and replay). */
+    agentViewUrl?: string | null;
     /** The agent's most recent final answer: free-form text, or structured data when the agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the changes endpoint, surfaced here for non-interactive runs. */
     latestAnswer?: unknown;
     createdAt: Date;

--- a/packages/sdk/src/client/api/types/SessionSummary.ts
+++ b/packages/sdk/src/client/api/types/SessionSummary.ts
@@ -9,6 +9,8 @@ export interface SessionSummary {
     id: string;
     agent?: string | null;
     status: HaiAgents.TrajectoryStatus;
+    /** URL of the session's Agent View page on the H Platform (live view and replay). */
+    agentViewUrl?: string | null;
     firstMessage?: HaiAgents.UserMessageEvent | null;
     createdAt: Date;
     startedAt?: Date | null;

--- a/packages/sdk/src/client/serialization/types/Session.ts
+++ b/packages/sdk/src/client/serialization/types/Session.ts
@@ -11,6 +11,7 @@ export const Session: core.serialization.ObjectSchema<serializers.Session.Raw, H
         id: core.serialization.string(),
         request: SessionRequest,
         status: SessionStatus,
+        agentViewUrl: core.serialization.property("agent_view_url", core.serialization.string().optionalNullable()),
         latestAnswer: core.serialization.property("latest_answer", core.serialization.unknown().optional()),
         createdAt: core.serialization.property("created_at", core.serialization.date()),
         startedAt: core.serialization.property("started_at", core.serialization.date().optionalNullable()),
@@ -22,6 +23,7 @@ export declare namespace Session {
         id: string;
         request: SessionRequest.Raw;
         status: SessionStatus.Raw;
+        agent_view_url?: (string | null | undefined) | null;
         latest_answer?: unknown | null;
         created_at: string;
         started_at?: (string | null | undefined) | null;

--- a/packages/sdk/src/client/serialization/types/SessionSummary.ts
+++ b/packages/sdk/src/client/serialization/types/SessionSummary.ts
@@ -11,6 +11,7 @@ export const SessionSummary: core.serialization.ObjectSchema<serializers.Session
         id: core.serialization.string(),
         agent: core.serialization.string().optionalNullable(),
         status: TrajectoryStatus,
+        agentViewUrl: core.serialization.property("agent_view_url", core.serialization.string().optionalNullable()),
         firstMessage: core.serialization.property("first_message", UserMessageEvent.optionalNullable()),
         createdAt: core.serialization.property("created_at", core.serialization.date()),
         startedAt: core.serialization.property("started_at", core.serialization.date().optionalNullable()),
@@ -22,6 +23,7 @@ export declare namespace SessionSummary {
         id: string;
         agent?: (string | null | undefined) | null;
         status: TrajectoryStatus.Raw;
+        agent_view_url?: (string | null | undefined) | null;
         first_message?: (UserMessageEvent.Raw | null | undefined) | null;
         created_at: string;
         started_at?: (string | null | undefined) | null;


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.6` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@f57ac85


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
