### PR TITLE
Restore const+default discriminator defaults in serializers

### DIFF
--- a/packages/sdk/src/client/core/schemas/builders/object/index.ts
+++ b/packages/sdk/src/client/core/schemas/builders/object/index.ts
@@ -20,3 +20,4 @@ export type {
     ObjectUtils,
     PropertySchemas,
 } from "./types.js";
+export { withJsonDefaults } from "./withJsonDefaults.js";

--- a/packages/sdk/src/client/core/schemas/builders/object/withJsonDefaults.ts
+++ b/packages/sdk/src/client/core/schemas/builders/object/withJsonDefaults.ts
@@ -1,0 +1,31 @@
+import { isPlainObject } from "../../utils/isPlainObject.js";
+import { getObjectLikeUtils } from "../object-like/index.js";
+import { getSchemaUtils } from "../schema-utils/index.js";
+import { getObjectUtils } from "./object.js";
+import type { BaseObjectSchema, ObjectSchema } from "./types.js";
+
+/**
+ * Fills in missing properties with constant defaults before serializing to JSON.
+ *
+ * The API discriminates several tagged unions on a constant field whose default the
+ * generator drops; without this the field is omitted from the wire payload and the
+ * server rejects the request with a 422 before per-variant defaults are applied.
+ */
+export function withJsonDefaults<Raw, Parsed>(
+    schema: ObjectSchema<Raw, Parsed>,
+    defaults: Partial<Parsed>,
+): ObjectSchema<Raw, Parsed> {
+    const base: BaseObjectSchema<Raw, Parsed> = {
+        _getRawProperties: () => schema._getRawProperties(),
+        _getParsedProperties: () => schema._getParsedProperties(),
+        parse: (raw, opts) => schema.parse(raw, opts),
+        json: (parsed, opts) => schema.json(isPlainObject(parsed) ? { ...defaults, ...parsed } : parsed, opts),
+        getType: () => schema.getType(),
+    };
+    return {
+        ...base,
+        ...getSchemaUtils(base),
+        ...getObjectLikeUtils(base),
+        ...getObjectUtils(base),
+    };
+}

--- a/packages/sdk/src/client/serialization/types/Browser.ts
+++ b/packages/sdk/src/client/serialization/types/Browser.ts
@@ -7,7 +7,7 @@ import { BrowserKind } from "./BrowserKind.js";
 import { BrowserMode } from "./BrowserMode.js";
 
 export const Browser: core.serialization.ObjectSchema<serializers.Browser.Raw, HaiAgents.Browser> =
-    core.serialization.object({
+    core.serialization.withJsonDefaults(core.serialization.object({
         id: core.serialization.string(),
         kind: BrowserKind.optional(),
         headless: core.serialization.boolean().optional(),
@@ -17,7 +17,7 @@ export const Browser: core.serialization.ObjectSchema<serializers.Browser.Raw, H
         mode: BrowserMode.optional(),
         pageChars: core.serialization.property("page_chars", core.serialization.number().optional()),
         vaultId: core.serialization.property("vault_id", core.serialization.string().optionalNullable()),
-    });
+    }), { kind: "web" });
 
 export declare namespace Browser {
     export interface Raw {

--- a/packages/sdk/src/client/serialization/types/OnePasswordConfig.ts
+++ b/packages/sdk/src/client/serialization/types/OnePasswordConfig.ts
@@ -8,10 +8,10 @@ import { OnePasswordConfigProvider } from "./OnePasswordConfigProvider.js";
 export const OnePasswordConfig: core.serialization.ObjectSchema<
     serializers.OnePasswordConfig.Raw,
     HaiAgents.OnePasswordConfig
-> = core.serialization.object({
+> = core.serialization.withJsonDefaults(core.serialization.object({
     provider: OnePasswordConfigProvider.optional(),
     opVaultId: core.serialization.property("op_vault_id", core.serialization.string()),
-});
+}), { provider: "onepassword" });
 
 export declare namespace OnePasswordConfig {
     export interface Raw {

--- a/packages/sdk/src/client/serialization/types/ToolResultEvent.ts
+++ b/packages/sdk/src/client/serialization/types/ToolResultEvent.ts
@@ -8,12 +8,12 @@ import { ToolResultEventType } from "./ToolResultEventType.js";
 export const ToolResultEvent: core.serialization.ObjectSchema<
     serializers.ToolResultEvent.Raw,
     HaiAgents.ToolResultEvent
-> = core.serialization.object({
+> = core.serialization.withJsonDefaults(core.serialization.object({
     type: ToolResultEventType.optional(),
     toolCallId: core.serialization.property("tool_call_id", core.serialization.string()),
     result: core.serialization.unknown().optional(),
     isError: core.serialization.property("is_error", core.serialization.boolean().optional()),
-});
+}), { type: "tool_result" });
 
 export declare namespace ToolResultEvent {
     export interface Raw {

--- a/packages/sdk/src/client/serialization/types/UserMessageEvent.ts
+++ b/packages/sdk/src/client/serialization/types/UserMessageEvent.ts
@@ -8,12 +8,12 @@ import { UserMessageEventType } from "./UserMessageEventType.js";
 export const UserMessageEvent: core.serialization.ObjectSchema<
     serializers.UserMessageEvent.Raw,
     HaiAgents.UserMessageEvent
-> = core.serialization.object({
+> = core.serialization.withJsonDefaults(core.serialization.object({
     type: UserMessageEventType.optional(),
     message: core.serialization.string(),
     images: core.serialization.list(core.serialization.string()).optional(),
     callerId: core.serialization.property("caller_id", core.serialization.string().optional()),
-});
+}), { type: "user_message" });
 
 export declare namespace UserMessageEvent {
     export interface Raw {

--- a/packages/sdk/tests/specDefaults.test.ts
+++ b/packages/sdk/tests/specDefaults.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { serialization } from "../src/client/index.js";
+
+// The API discriminates several tagged unions on a constant field (Browser.kind, event type
+// tags). The spec declares those fields with const+default, but the Fern generator drops the
+// default, the serializer omits the field, and the server 422s on union discrimination. The
+// codegen pipeline restores the defaults post-generation; these tests fail loudly if a future
+// regeneration ships without them.
+
+const spec = JSON.parse(readFileSync(join(__dirname, "../../../openapi.json"), "utf-8"));
+
+// Tag carried by the per-endpoint request-body wrappers instead of the model itself.
+const FIELD_DROPPED_ENTIRELY = new Set(["ToolResultBatch.type", "UserMessageBatch.type"]);
+
+const MINIMAL_PARSED: Record<string, object> = {
+    Browser: { id: "browser" },
+    OnePasswordConfig: { opVaultId: "vault_1" },
+    ToolResultEvent: { toolCallId: "call_1", result: "ok" },
+    UserMessageEvent: { message: "hi" },
+};
+
+function specConstDefaults(): [string, string, string][] {
+    const cases: [string, string, string][] = [];
+    for (const [schemaName, schema] of Object.entries<any>(spec.components.schemas)) {
+        for (const [propName, prop] of Object.entries<any>(schema.properties ?? {})) {
+            if (prop != null && typeof prop === "object" && "const" in prop && "default" in prop) {
+                cases.push([schemaName, propName, prop.default]);
+            }
+        }
+    }
+    return cases;
+}
+
+describe("spec const+default discriminators", () => {
+    it("spec still declares the known discriminator defaults", () => {
+        const found = new Set(specConstDefaults().map(([s, p]) => `${s}.${p}`));
+        expect(found).toContain("Browser.kind");
+        expect(found).toContain("OnePasswordConfig.provider");
+    });
+
+    it.each(specConstDefaults().filter(([s, p]) => !FIELD_DROPPED_ENTIRELY.has(`${s}.${p}`)))(
+        "%s.%s serializes to %s when omitted",
+        (schemaName, propName, expectedDefault) => {
+            const schema = (serialization as Record<string, any>)[schemaName];
+            expect(schema, `no serializer exported for ${schemaName}`).toBeDefined();
+            const raw = schema.jsonOrThrow(MINIMAL_PARSED[schemaName] ?? {});
+            expect(raw[propName]).toBe(expectedDefault);
+        },
+    );
+
+    it("injects kind through the inline-agent environments path", () => {
+        const raw = serialization.AgentEnvironmentsItem.jsonOrThrow({ id: "browser" });
+        expect((raw as any).kind).toBe("web");
+    });
+});


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound request JSON for several API types; behavior is intentional and guarded by OpenAPI-driven tests, but any client depending on omitting those tags could see different payloads.
> 
> **Overview**
> Adds **`withJsonDefaults`**, a schema wrapper that merges constant defaults into parsed objects **only at JSON serialization time**, so optional discriminator fields from the OpenAPI spec are still sent on the wire when callers omit them.
> 
> **Browser**, **OnePasswordConfig**, **ToolResultEvent**, and **UserMessageEvent** serializers are wrapped with the matching defaults (`kind: "web"`, `provider: "onepassword"`, `type: "tool_result"`, `type: "user_message"`). This addresses Fern dropping `const`+`default` fields, which previously caused the API to **422** on union discrimination.
> 
> New **`specDefaults.test.ts`** scans `openapi.json` for `const`+`default` properties and asserts each exported serializer injects the expected value when the field is omitted, including the **AgentEnvironmentsItem** browser path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8920e730a3fe3eb8333a41f234230685be5ea77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->