### PR TITLE
Stop polling when a session idles awaiting the next message

### DIFF
--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -9,9 +9,11 @@ export { SessionHandle } from "./polling.js";
 export {
   AnswerValidationError,
   MAX_REQUEST_BYTES,
+  SETTLED_SESSION_STATUSES,
   TERMINAL_SESSION_STATUSES,
   assertRequestUnderLimit,
   attachToolDefinitions,
+  isSettledSessionStatus,
   isTerminalSessionStatus,
   runSession,
   waitForSession,

--- a/packages/sdk/src/client/polling.ts
+++ b/packages/sdk/src/client/polling.ts
@@ -19,6 +19,13 @@ export const TERMINAL_SESSION_STATUSES = [
   "interrupted",
 ] as const satisfies readonly TrajectoryStatus[];
 
+// Polling also stops on "idle": the agent finished its turn and is waiting for the next
+// user message, which a one-shot wait will never send.
+export const SETTLED_SESSION_STATUSES = [
+  ...TERMINAL_SESSION_STATUSES,
+  "idle",
+] as const satisfies readonly TrajectoryStatus[];
+
 /** Server rejects request bodies above this size; enforced client-side for a clear early error. */
 export const MAX_REQUEST_BYTES = 5 * 1024 * 1024;
 
@@ -30,7 +37,8 @@ export type SessionRunResult<TAnswer = TrajectoryChanges["answer"]> = {
   finalChanges?: TrajectoryChanges;
   /**
    * The session's final answer: the parsed `answerSchema` value when one was requested and
-   * the session completed, otherwise the raw wire value (also at `finalChanges.answer`).
+   * the session completed or idled with an answer, otherwise the raw wire value (also at
+   * `finalChanges.answer`).
    */
   answer?: TAnswer;
 };
@@ -97,8 +105,12 @@ function parseAnswer<TAnswer>(
   status: TrajectoryStatus,
   schema: AnswerSchema<TAnswer> | undefined,
 ): TAnswer | undefined {
-  if (schema === undefined || status !== "completed") {
+  if (schema === undefined || (status !== "completed" && status !== "idle")) {
     return raw as TAnswer | undefined;
+  }
+  // An idle session may legitimately have no answer yet; a completed one must parse.
+  if (status === "idle" && raw == null) {
+    return undefined;
   }
   // The wire answer may arrive as JSON text rather than an object.
   let candidate: unknown = raw;
@@ -161,6 +173,9 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 export const isTerminalSessionStatus = (status: TrajectoryStatus): boolean =>
   (TERMINAL_SESSION_STATUSES as readonly string[]).includes(status);
+
+export const isSettledSessionStatus = (status: TrajectoryStatus): boolean =>
+  (SETTLED_SESSION_STATUSES as readonly string[]).includes(status);
 
 export function assertRequestUnderLimit(payload: unknown, maxBytes: number = MAX_REQUEST_BYTES): void {
   const bytes = new TextEncoder().encode(JSON.stringify(payload ?? {})).length;
@@ -283,9 +298,9 @@ async function recoverPendingToolCalls(client: HaiAgentsClient, id: string): Pro
 }
 
 /**
- * Poll a session until it reaches a terminal status.
+ * Poll a session until it settles: a terminal status, or idle awaiting the next message.
  *
- * Terminal state is read from `/status` (authoritative); `/changes` only feeds events
+ * Status is read from `/status` (authoritative); `/changes` only feeds events
  * and the final answer, since it 204s whenever no new events exist past `fromIndex` --
  * even after the session has finished.
  */
@@ -318,7 +333,7 @@ export async function waitForSession<TAnswer = TrajectoryChanges["answer"]>(
 
   for (let polls = 0; maxPolls === undefined || polls < maxPolls; polls += 1) {
     if (deadline !== undefined && Date.now() >= deadline) {
-      throw new Error(`Session ${id} did not reach a terminal status within ${timeoutMs}ms`);
+      throw new Error(`Session ${id} did not settle within ${timeoutMs}ms`);
     }
 
     let batch: TrajectoryEvent[] = [];
@@ -339,7 +354,7 @@ export async function waitForSession<TAnswer = TrajectoryChanges["answer"]>(
     }
 
     const { status } = await client.sessions.getSessionStatus({ id });
-    if (isTerminalSessionStatus(status)) {
+    if (isSettledSessionStatus(status)) {
       const changes = await finalChanges(client, id, lastChanges, limit);
       const answer = parseAnswer(changes?.answer, status, answerSchema);
       return { id, status, events, nextFromIndex, finalChanges: changes, answer };
@@ -371,7 +386,7 @@ export async function waitForSession<TAnswer = TrajectoryChanges["answer"]>(
     }
   }
 
-  throw new Error(`Session ${id} did not reach a terminal status before maxPolls=${maxPolls}`);
+  throw new Error(`Session ${id} did not settle before maxPolls=${maxPolls}`);
 }
 
 export async function runSession<TAnswer = TrajectoryChanges["answer"]>(
@@ -439,7 +454,7 @@ export class SessionHandle<TAnswer = TrajectoryChanges["answer"]> {
     return this.client.sessions.forceSessionAnswer({ id: this.id });
   }
 
-  /** Block until the session reaches a terminal status; resolves with the result and final answer. */
+  /** Block until the session settles (terminal or idle); resolves with the result and final answer. */
   waitForCompletion(options?: Omit<WaitForSessionOptions<TAnswer>, "id">): Promise<SessionRunResult<TAnswer>> {
     return waitForSession(this.client, { id: this.id, answerSchema: this.answerSchema, tools: this.tools, ...options });
   }

--- a/packages/sdk/tests/settle.test.ts
+++ b/packages/sdk/tests/settle.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { HaiAgentsClient } from "../src/client/Client.js";
+import { waitForSession } from "../src/client/polling.js";
+
+// Polling stops when a session settles: terminal, or idle awaiting the next message.
+
+function fakeClient(statuses: string[], answer: unknown = null) {
+  let changesIdx = 0;
+  let statusIdx = 0;
+  return {
+    sessions: {
+      getSessionChanges: async () => ({
+        status: statuses[Math.min(changesIdx++, statuses.length - 1)],
+        newEvents: [],
+        answer,
+      }),
+      getSessionStatus: async () => ({ status: statuses[Math.min(statusIdx++, statuses.length - 1)] }),
+    },
+  } as unknown as HaiAgentsClient;
+}
+
+describe("waitForSession settling on idle", () => {
+  it("stops on idle and returns the answer", async () => {
+    const result = await waitForSession(fakeClient(["running", "idle"], "done"), { id: "s1", waitForSeconds: 0 });
+    expect(result.status).toBe("idle");
+    expect(result.answer).toBe("done");
+  });
+
+  it("parses an idle answer into the answerSchema", async () => {
+    const schema = z.object({ text: z.string() });
+    const result = await waitForSession(fakeClient(["idle"], '{"text":"hi"}'), {
+      id: "s1",
+      waitForSeconds: 0,
+      answerSchema: schema,
+    });
+    expect(result.answer).toEqual({ text: "hi" });
+  });
+
+  it("returns undefined when idle has no answer despite a schema", async () => {
+    const schema = z.object({ text: z.string() });
+    const result = await waitForSession(fakeClient(["idle"], null), {
+      id: "s1",
+      waitForSeconds: 0,
+      answerSchema: schema,
+    });
+    expect(result.answer).toBeUndefined();
+  });
+});


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `waitForSession` and related helpers resolve, which can affect any integration that relied on polling past `idle`; behavior is intentional but is a public API semantic change.
> 
> **Overview**
> **Session polling now stops when a session is `idle`**, not only on terminal statuses (`completed`, `failed`, etc.). One-shot `waitForSession` / `runSession` / `SessionHandle.waitForCompletion` calls no longer spin until timeout when the agent has finished its turn and is waiting for another user message.
> 
> The SDK adds **`SETTLED_SESSION_STATUSES`** (terminal statuses plus `idle`) and **`isSettledSessionStatus`**, and `waitForSession` uses that instead of `isTerminalSessionStatus`. **`parseAnswer`** applies `answerSchema` when status is `completed` or `idle`, returns `undefined` for idle with no answer, and docs/errors refer to “settle” rather than “terminal.”
> 
> New **`settle.test.ts`** covers idle stop behavior and answer parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67281484df56adf967e7ab1e30138aa139d1f5be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->