### PR TITLE
chore(sdk): sync to agent_platform@f4a2225 (v0.1.7)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2826,6 +2826,7 @@
         "type": "string",
         "enum": [
           "web",
+          "desktop",
           "code",
           "mcp",
           "memory"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/api/types/EnvironmentKind.ts
+++ b/packages/sdk/src/client/api/types/EnvironmentKind.ts
@@ -3,6 +3,7 @@
 /** Environment family. */
 export const EnvironmentKind = {
     Web: "web",
+    Desktop: "desktop",
     Code: "code",
     Mcp: "mcp",
     Memory: "memory",

--- a/packages/sdk/src/client/serialization/types/EnvironmentKind.ts
+++ b/packages/sdk/src/client/serialization/types/EnvironmentKind.ts
@@ -5,8 +5,8 @@ import * as core from "../../core/index.js";
 import type * as serializers from "../index.js";
 
 export const EnvironmentKind: core.serialization.Schema<serializers.EnvironmentKind.Raw, HaiAgents.EnvironmentKind> =
-    core.serialization.enum_(["web", "code", "mcp", "memory"]);
+    core.serialization.enum_(["web", "desktop", "code", "mcp", "memory"]);
 
 export declare namespace EnvironmentKind {
-    export type Raw = "web" | "code" | "mcp" | "memory";
+    export type Raw = "web" | "desktop" | "code" | "mcp" | "memory";
 }


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.7` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@f4a2225


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
