### PR TITLE
chore(sdk): sync to agent_platform@5697e81 (v0.1.7)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2825,10 +2825,7 @@
       "EnvironmentKind": {
         "type": "string",
         "enum": [
-          "web",
-          "code",
-          "mcp",
-          "memory"
+          "web"
         ],
         "title": "EnvironmentKind",
         "description": "Environment family."

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/api/types/EnvironmentKind.ts
+++ b/packages/sdk/src/client/api/types/EnvironmentKind.ts
@@ -3,8 +3,5 @@
 /** Environment family. */
 export const EnvironmentKind = {
     Web: "web",
-    Code: "code",
-    Mcp: "mcp",
-    Memory: "memory",
 } as const;
 export type EnvironmentKind = (typeof EnvironmentKind)[keyof typeof EnvironmentKind];

--- a/packages/sdk/src/client/serialization/types/EnvironmentKind.ts
+++ b/packages/sdk/src/client/serialization/types/EnvironmentKind.ts
@@ -5,8 +5,8 @@ import * as core from "../../core/index.js";
 import type * as serializers from "../index.js";
 
 export const EnvironmentKind: core.serialization.Schema<serializers.EnvironmentKind.Raw, HaiAgents.EnvironmentKind> =
-    core.serialization.enum_(["web", "code", "mcp", "memory"]);
+    core.serialization.enum_(["web"]);
 
 export declare namespace EnvironmentKind {
-    export type Raw = "web" | "code" | "mcp" | "memory";
+    export type Raw = "web";
 }


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.7` (patch; every sync bumps +0.0.1) · upstream flagged this a breaking change
**Upstream:** agent_platform@5697e81


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
