### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TypeScript SDK for H Company's Agent API: autonomous agents powered by Holo.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Aligns the npm version with the Python SDK release.

Made with [Cursor](https://cursor.com)