### PR TITLE
Fix README quickstart: flat runSession options and HAI_API_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install hai-agents
 Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
 
 ```bash
-export H_API_KEY=hk-...
+export HAI_API_KEY=hk-...
 ```
 
 ## Quickstart
@@ -46,7 +46,7 @@ Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own b
 ```ts
 import { HaiAgentsClient, runSession } from "hai-agents";
 
-const client = new HaiAgentsClient(); // reads H_API_KEY from the environment
+const client = new HaiAgentsClient(); // reads HAI_API_KEY from the environment
 
 const result = await runSession(client, {
   agent: "h/web-surfer-holo3-1-35b",

--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ import { HaiAgentsClient, runSession } from "hai-agents";
 const client = new HaiAgentsClient(); // reads H_API_KEY from the environment
 
 const result = await runSession(client, {
-  body: {
-    agent: "h/web-surfer-holo3-1-35b",
-    messages: "What are the top 3 stories on Hacker News right now?",
-  },
+  agent: "h/web-surfer-holo3-1-35b",
+  messages: "What are the top 3 stories on Hacker News right now?",
 });
 
 console.log(result.status); // "completed"

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -36,7 +36,7 @@ npm install hai-agents
 Requires Node.js 18 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
 
 ```bash
-export H_API_KEY=hk-...
+export HAI_API_KEY=hk-...
 ```
 
 ## Quickstart
@@ -46,7 +46,7 @@ Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own b
 ```ts
 import { HaiAgentsClient, runSession } from "hai-agents";
 
-const client = new HaiAgentsClient(); // reads H_API_KEY from the environment
+const client = new HaiAgentsClient(); // reads HAI_API_KEY from the environment
 
 const result = await runSession(client, {
   agent: "h/web-surfer-holo3-1-35b",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -49,10 +49,8 @@ import { HaiAgentsClient, runSession } from "hai-agents";
 const client = new HaiAgentsClient(); // reads H_API_KEY from the environment
 
 const result = await runSession(client, {
-  body: {
-    agent: "h/web-surfer-holo3-1-35b",
-    messages: "What are the top 3 stories on Hacker News right now?",
-  },
+  agent: "h/web-surfer-holo3-1-35b",
+  messages: "What are the top 3 stories on Hacker News right now?",
 });
 
 console.log(result.status); // "completed"


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Docs-only, but if the client still reads `H_API_KEY` only, the updated env var name would break the advertised quickstart for new users.
> 
> **Overview**
> Updates the **root** and **`packages/sdk`** README quickstart so copy-paste examples match the SDK’s public API.
> 
> **`runSession`** is shown with **flat** session fields (`agent`, `messages`) on the options object instead of nesting them under `body`, consistent with `RunSessionOptions` / `CreateSessionParams`.
> 
> Installation and client comments now reference **`HAI_API_KEY`** instead of **`H_API_KEY`** for the default environment variable used by `HaiAgentsClient()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 174f4f9d71f073937c2013fe8a6500938554e86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->