### PR TITLE
docs: use canonical /computer-use-agents links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 </p>
 
 <p align="center">
-  TypeScript SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/agent-api">Computer-Use Agents</a>.
+  TypeScript SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/computer-use-agents">Computer-Use Agents</a>.
 </p>
 
 <p align="center">
-  <b><a href="https://hub.hcompany.ai/agent-api">Documentation</a></b>
+  <b><a href="https://hub.hcompany.ai/computer-use-agents">Documentation</a></b>
   &nbsp;·&nbsp;
   <a href="https://portal.hcompany.ai">Get an API key</a>
   &nbsp;·&nbsp;
@@ -173,7 +173,7 @@ Tool functions may be sync or async. A tool that throws is reported to the agent
 
 ## Browser profiles and vaults
 
-Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/agent-api) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/agent-api) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:
+Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/computer-use-agents/browser-profiles) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/computer-use-agents/vaults) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:
 
 ```ts
 const result = await client.runSession({
@@ -233,7 +233,7 @@ console.log(event.type, event.data);
 
 ## Documentation
 
-Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/computer-use-agents](https://hub.hcompany.ai/computer-use-agents)**.
 
 ## License
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -12,11 +12,11 @@
 </p>
 
 <p align="center">
-  TypeScript SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/agent-api">Computer-Use Agents</a>.
+  TypeScript SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/computer-use-agents">Computer-Use Agents</a>.
 </p>
 
 <p align="center">
-  <b><a href="https://hub.hcompany.ai/agent-api">Documentation</a></b>
+  <b><a href="https://hub.hcompany.ai/computer-use-agents">Documentation</a></b>
   &nbsp;·&nbsp;
   <a href="https://portal.hcompany.ai">Get an API key</a>
   &nbsp;·&nbsp;
@@ -173,7 +173,7 @@ Tool functions may be sync or async. A tool that throws is reported to the agent
 
 ## Browser profiles and vaults
 
-Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/agent-api) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/agent-api) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:
+Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/computer-use-agents/browser-profiles) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/computer-use-agents/vaults) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:
 
 ```ts
 const result = await client.runSession({
@@ -233,7 +233,7 @@ console.log(event.type, event.data);
 
 ## Documentation
 
-Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/computer-use-agents](https://hub.hcompany.ai/computer-use-agents)**.
 
 ## License
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,7 +11,7 @@
     "sdk",
     "h-company"
   ],
-  "homepage": "https://hub.hcompany.ai/agent-api",
+  "homepage": "https://hub.hcompany.ai/computer-use-agents",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hcompai/hai-agents-ts.git",


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and metadata URL changes only; no runtime or API behavior is affected.
> 
> **Overview**
> Documentation and package metadata now point at the canonical **hub.hcompany.ai/computer-use-agents** hub instead of **agent-api**.
> 
> Root and `packages/sdk` READMEs update the main docs links, the browser profile and vault deep links (`/browser-profiles`, `/vaults`), and the documentation section footer. **`hai-agents`** `package.json` **`homepage`** is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d143cdda5fb69c3e492373c72322224d951d3f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->