### PR TITLE
chore(sdk): sync to agent_platform@85623ee (v1.0.1)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Agent API",
+    "title": "Computer-Use Agents",
     "version": "1.0.0"
   },
   "servers": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript SDK for H Company's Computer-Use Agents: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/BaseClient.ts
+++ b/packages/sdk/src/client/BaseClient.ts
@@ -57,9 +57,9 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
 ): NormalizedClientOptions<T> {
     const headers = mergeHeaders(
         {
-            "User-Agent": "hai-agents/1.0.0",
+            "User-Agent": "hai-agents/1.0.1",
             "X-HCompany-Client-Name": "hai-agents",
-            "X-HCompany-Client-Version": "1.0.0",
+            "X-HCompany-Client-Version": "1.0.1",
             "X-HCompany-Client-Type": "sdk",
             "X-HCompany-Language": "JavaScript",
             "X-HCompany-Runtime": core.RUNTIME.type,


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `1.0.1` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@85623ee


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
