### PR TITLE
chore(sdk): sync to agent_platform@8104a99 (v1.0.2)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1306,7 +1306,7 @@
           "Skills"
         ],
         "summary": "List Skills",
-        "description": "List reserved + caller's org skills, optionally filtered by name or text search.",
+        "description": "List reserved + caller's org skills. Unauthenticated callers see reserved ``h/`` skills only.",
         "operationId": "list_skills_api_v2_skills_get",
         "security": [
           {
@@ -1682,7 +1682,7 @@
           "Environments"
         ],
         "summary": "List Environments",
-        "description": "List reserved + caller's org environments.",
+        "description": "List reserved + caller's org environments. Unauthenticated callers see reserved ``h/`` environments only.",
         "operationId": "list_environments_api_v2_environments_get",
         "security": [
           {
@@ -2076,7 +2076,7 @@
           "Agents"
         ],
         "summary": "List Agents",
-        "description": "List reserved + caller's org agents.",
+        "description": "List reserved + caller's org agents. Unauthenticated callers see reserved ``h/`` agents only.",
         "operationId": "list_agents_api_v2_agents_get",
         "security": [
           {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "TypeScript SDK for H Company's Computer-Use Agents: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/BaseClient.ts
+++ b/packages/sdk/src/client/BaseClient.ts
@@ -57,9 +57,9 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
 ): NormalizedClientOptions<T> {
     const headers = mergeHeaders(
         {
-            "User-Agent": "hai-agents/1.0.1",
+            "User-Agent": "hai-agents/1.0.2",
             "X-HCompany-Client-Name": "hai-agents",
-            "X-HCompany-Client-Version": "1.0.1",
+            "X-HCompany-Client-Version": "1.0.2",
             "X-HCompany-Client-Type": "sdk",
             "X-HCompany-Language": "JavaScript",
             "X-HCompany-Runtime": core.RUNTIME.type,

--- a/packages/sdk/src/client/api/resources/agents/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/agents/client/Client.ts
@@ -25,7 +25,7 @@ export class AgentsClient {
     }
 
     /**
-     * List reserved + caller's org agents.
+     * List reserved + caller's org agents. Unauthenticated callers see reserved ``h/`` agents only.
      *
      * @param {HaiAgents.ListAgentsRequest} request
      * @param {AgentsClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/packages/sdk/src/client/api/resources/environments/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/environments/client/Client.ts
@@ -25,7 +25,7 @@ export class EnvironmentsClient {
     }
 
     /**
-     * List reserved + caller's org environments.
+     * List reserved + caller's org environments. Unauthenticated callers see reserved ``h/`` environments only.
      *
      * @param {HaiAgents.ListEnvironmentsRequest} request
      * @param {EnvironmentsClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/packages/sdk/src/client/api/resources/skills/client/Client.ts
+++ b/packages/sdk/src/client/api/resources/skills/client/Client.ts
@@ -25,7 +25,7 @@ export class SkillsClient {
     }
 
     /**
-     * List reserved + caller's org skills, optionally filtered by name or text search.
+     * List reserved + caller's org skills. Unauthenticated callers see reserved ``h/`` skills only.
      *
      * @param {HaiAgents.ListSkillsRequest} request
      * @param {SkillsClient.RequestOptions} requestOptions - Request-specific configuration.


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `1.0.2` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@8104a99


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
