### PR TITLE
Fix out-of-sync TS SDK content (agent name, API key URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export HAI_API_KEY=hk-...
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSession` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-pro` agent, which ships with its own browser, and describe the task in plain language. `runSession` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient } from "hai-agents";
@@ -49,7 +49,7 @@ import { HaiAgentsClient } from "hai-agents";
 const client = new HaiAgentsClient(); // reads HAI_API_KEY from the environment
 
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "What are the top 3 stories on Hacker News right now?",
 });
 
@@ -67,7 +67,7 @@ You drive a session two ways. `runSession` creates it and resolves once it settl
 
 ```ts
 const session = await client.startSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "Find the top story on Hacker News",
 });
 
@@ -104,7 +104,7 @@ By default a session ends as soon as the agent answers. Set `idleTimeoutS` to ke
 
 ```ts
 const session = await client.startSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   idleTimeoutS: 600,
   messages: "Find the top story on Hacker News",
 });
@@ -128,7 +128,7 @@ const Jobs = z.object({
 
 const client = new HaiAgentsClient();
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "Find 3 open ML engineering roles in Paris.",
   answerSchema: Jobs,
 });
@@ -161,7 +161,7 @@ const getWeather = tool({
 const client = new HaiAgentsClient();
 
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "What should I wear in Paris today?",
   tools: [getWeather],
 });
@@ -177,7 +177,7 @@ Start a session on a browser that already knows the user. A [browser profile](ht
 
 ```ts
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "Open my dashboard and report any new alerts",
   overrides: {
     "agent.environments[kind=web].browser_profile_id": "<profile-id>",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <b><a href="https://hub.hcompany.ai/computer-use-agents">Documentation</a></b>
   &nbsp;·&nbsp;
-  <a href="https://portal.hcompany.ai">Get an API key</a>
+  <a href="https://platform.hcompany.ai/settings/api-keys">Get an API key</a>
   &nbsp;·&nbsp;
   <a href="https://www.npmjs.com/package/hai-agents">npm</a>
   &nbsp;·&nbsp;
@@ -33,7 +33,7 @@
 npm install hai-agents
 ```
 
-Node.js 18 or newer is required. Get an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
+Node.js 18 or newer is required. Get an API key at [platform.hcompany.ai/settings/api-keys](https://platform.hcompany.ai/settings/api-keys) and export it:
 
 ```bash
 export HAI_API_KEY=hk-...

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -41,7 +41,7 @@ export HAI_API_KEY=hk-...
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `runSession` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-pro` agent, which ships with its own browser, and describe the task in plain language. `runSession` polls until the agent finishes and returns the final answer.
 
 ```ts
 import { HaiAgentsClient } from "hai-agents";
@@ -49,7 +49,7 @@ import { HaiAgentsClient } from "hai-agents";
 const client = new HaiAgentsClient(); // reads HAI_API_KEY from the environment
 
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "What are the top 3 stories on Hacker News right now?",
 });
 
@@ -67,7 +67,7 @@ You drive a session two ways. `runSession` creates it and resolves once it settl
 
 ```ts
 const session = await client.startSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "Find the top story on Hacker News",
 });
 
@@ -104,7 +104,7 @@ By default a session ends as soon as the agent answers. Set `idleTimeoutS` to ke
 
 ```ts
 const session = await client.startSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   idleTimeoutS: 600,
   messages: "Find the top story on Hacker News",
 });
@@ -128,7 +128,7 @@ const Jobs = z.object({
 
 const client = new HaiAgentsClient();
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "Find 3 open ML engineering roles in Paris.",
   answerSchema: Jobs,
 });
@@ -161,7 +161,7 @@ const getWeather = tool({
 const client = new HaiAgentsClient();
 
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "What should I wear in Paris today?",
   tools: [getWeather],
 });
@@ -177,7 +177,7 @@ Start a session on a browser that already knows the user. A [browser profile](ht
 
 ```ts
 const result = await client.runSession({
-  agent: "h/web-surfer-holo3-1-35b",
+  agent: "h/web-surfer-pro",
   messages: "Open my dashboard and report any new alerts",
   overrides: {
     "agent.environments[kind=web].browser_profile_id": "<profile-id>",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <b><a href="https://hub.hcompany.ai/computer-use-agents">Documentation</a></b>
   &nbsp;·&nbsp;
-  <a href="https://portal.hcompany.ai">Get an API key</a>
+  <a href="https://platform.hcompany.ai/settings/api-keys">Get an API key</a>
   &nbsp;·&nbsp;
   <a href="https://www.npmjs.com/package/hai-agents">npm</a>
   &nbsp;·&nbsp;
@@ -33,7 +33,7 @@
 npm install hai-agents
 ```
 
-Node.js 18 or newer is required. Get an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
+Node.js 18 or newer is required. Get an API key at [platform.hcompany.ai/settings/api-keys](https://platform.hcompany.ai/settings/api-keys) and export it:
 
 ```bash
 export HAI_API_KEY=hk-...

--- a/packages/sdk/tests/answerSchema.test.ts
+++ b/packages/sdk/tests/answerSchema.test.ts
@@ -45,7 +45,7 @@ describe("attachAnswerSchema", () => {
 
   it("injects via overrides for catalog agent strings, preserving user overrides", async () => {
     const params = await attachAnswerSchema(
-      { agent: "h/web-surfer", overrides: { "agent.max_steps": 5 } } as never,
+      { agent: "h/web-surfer-pro", overrides: { "agent.max_steps": 5 } } as never,
       Jobs,
     );
     expect(params.overrides?.["agent.max_steps"]).toBe(5);
@@ -69,7 +69,7 @@ describe("answer parse-back", () => {
   it("parses a completed answer into the schema type", async () => {
     const { client, createdWith } = fakeClient(VALID_ANSWER);
     const result = await runSession(client, {
-      agent: "h/web-surfer",
+      agent: "h/web-surfer-pro",
       messages: "find jobs",
       answerSchema: Jobs,
     });

--- a/packages/sdk/tests/tools.test.ts
+++ b/packages/sdk/tests/tools.test.ts
@@ -58,8 +58,8 @@ function fakeClient(steps: Step[], postStatus = 200) {
 describe("attachToolDefinitions", () => {
   it("targets the agent.tools override for referenced and inline agents", () => {
     const expected = { "agent.tools": [{ name: add.name, description: add.description, input_schema: add.inputSchema }] };
-    const referenced = attachToolDefinitions({ agent: "h/web-surfer" }, [add]);
-    expect(referenced.agent).toBe("h/web-surfer");
+    const referenced = attachToolDefinitions({ agent: "h/web-surfer-pro" }, [add]);
+    expect(referenced.agent).toBe("h/web-surfer-pro");
     expect(referenced.overrides).toEqual(expected);
     const inline = attachToolDefinitions({ agent: { name: "a", environments: [] } as never }, [add]);
     expect(inline.overrides).toEqual(expected);


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test string updates only; no production SDK logic changed.
> 
> **Overview**
> Updates SDK documentation and tests to match the current **platform** onboarding URL and the **`h/web-surfer-pro`** catalog agent.
> 
> **Get an API key** links and install copy now use `platform.hcompany.ai/settings/api-keys` instead of `portal.hcompany.ai`. Quickstart and all session examples in `README.md` and `packages/sdk/README.md` replace `h/web-surfer-holo3-1-35b` with `h/web-surfer-pro`. Related tests in `answerSchema.test.ts` and `tools.test.ts` use the same agent id for catalog-agent scenarios.
> 
> No runtime SDK behavior changes—only docs and test fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50aeab91de4f0cac2c9d4923b48d695c99be8ee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->