### PR TITLE
Add engines field declaring Node 18+ requirement

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,6 +36,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --clean",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only manifest change with no runtime or API impact.
> 
> **Overview**
> Adds an **`engines`** field to **`packages/sdk/package.json`** so **`hai-agents`** documents a **Node.js `>=18`** requirement for installs and tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac3e204e1ee209b10a8e1223ef15dd540245114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->