### PR TITLE
feat(tools): enable OTP retrieval via HITL or IMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ console.log(result.answer);
 
 Tool functions may be sync or async. A tool that throws is reported to the agent as a tool error rather than crashing the run.
 
+### Prebuilt: one-time passwords (2FA)
+
+The SDK ships ready-made tools. `otpTool` lets the agent ask for a one-time password, verification code, or confirmation link when a login or signup step needs one. Without a handler it prompts on stdin; `imapOtpHandler` reads the code straight from a mailbox over IMAP (requires the optional dependencies `imapflow` and `mailparser`; for Gmail, use an app password).
+
+```ts
+import { HaiAgentsClient, imapOtpHandler, otpTool } from "hai-agents";
+
+const handler = imapOtpHandler({
+  host: "imap.gmail.com",
+  username: "agent-inbox@gmail.com",
+  password: process.env.GMAIL_APP_PASSWORD!,
+});
+
+const client = new HaiAgentsClient();
+const result = await client.runSession({
+  agent: "h/web-surfer-pro",
+  messages: "Log in to example.com and check for new notifications",
+  tools: [otpTool({ handler })],
+});
+```
+
+Like every custom tool, the handler runs entirely in your process: the IMAP credentials never leave your machine, and the agent only receives the single extracted code or link -- never mailbox contents.
+
 ## Browser profiles and vaults
 
 Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/computer-use-agents/browser-profiles) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/computer-use-agents/vaults) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -171,6 +171,29 @@ console.log(result.answer);
 
 Tool functions may be sync or async. A tool that throws is reported to the agent as a tool error rather than crashing the run.
 
+### Prebuilt: one-time passwords (2FA)
+
+The SDK ships ready-made tools. `otpTool` lets the agent ask for a one-time password, verification code, or confirmation link when a login or signup step needs one. Without a handler it prompts on stdin; `imapOtpHandler` reads the code straight from a mailbox over IMAP (requires the optional dependencies `imapflow` and `mailparser`; for Gmail, use an app password).
+
+```ts
+import { HaiAgentsClient, imapOtpHandler, otpTool } from "hai-agents";
+
+const handler = imapOtpHandler({
+  host: "imap.gmail.com",
+  username: "agent-inbox@gmail.com",
+  password: process.env.GMAIL_APP_PASSWORD!,
+});
+
+const client = new HaiAgentsClient();
+const result = await client.runSession({
+  agent: "h/web-surfer-pro",
+  messages: "Log in to example.com and check for new notifications",
+  tools: [otpTool({ handler })],
+});
+```
+
+Like every custom tool, the handler runs entirely in your process: the IMAP credentials never leave your machine, and the agent only receives the single extracted code or link -- never mailbox contents.
+
 ## Browser profiles and vaults
 
 Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/computer-use-agents/browser-profiles) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/computer-use-agents/vaults) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./client";
+export * from "./tools/otp.js";

--- a/packages/sdk/src/tools/otp.ts
+++ b/packages/sdk/src/tools/otp.ts
@@ -1,0 +1,312 @@
+/**
+ * Prebuilt OTP tool: hand the agent one-time passwords, verification codes, and
+ * confirmation links.
+ *
+ * The agent calls `otpTool` when a login or verification step asks for a code or link
+ * sent out of band; the handler resolves it -- interactively on stdin by default, or
+ * straight from a mailbox with `imapOtpHandler`.
+ */
+
+import { tool, type Tool } from "../client/tools.js";
+
+export const OTP_TOOL_NAME = "request_otp";
+
+export const OTP_TOOL_DESCRIPTION =
+  "Ask the human operator for a one-time password (OTP), verification code, or " +
+  "confirmation link. Use this whenever a login, signup, or verification step " +
+  "asks for a code or link that was sent to the user out of band (email, SMS, " +
+  "or an authenticator app). Never guess or fabricate a code: call this tool " +
+  "and wait for the value.";
+
+export const OTP_TOOL_INPUT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    prompt: {
+      type: "string",
+      description:
+        "Message shown to the user explaining exactly what is needed, " +
+        "e.g. 'Enter the 6-digit code sent to j***@example.com'.",
+    },
+    kind: {
+      type: "string",
+      enum: ["code", "link"],
+      default: "code",
+      description: "Whether a code (numeric or alphanumeric) or a full confirmation URL is expected.",
+    },
+    source: {
+      type: "string",
+      description: "Where the code or link was sent, e.g. 'email', 'sms', 'authenticator app'.",
+    },
+  },
+  required: ["prompt"],
+};
+
+/** One OTP request from the agent, passed to the `otpTool` handler. */
+export type OtpRequest = {
+  prompt: string;
+  kind: "code" | "link";
+  source?: string;
+};
+
+export type OtpHandler = (request: OtpRequest) => string | Promise<string>;
+
+export type OtpToolOptions = {
+  /**
+   * Resolves an `OtpRequest` to the value the user supplied (fetch the code from an
+   * inbox API, a Slack prompt, ...). Without one, the tool prompts interactively on
+   * stdin (Node.js only).
+   */
+  handler?: OtpHandler;
+  name?: string;
+  description?: string;
+};
+
+/** Interactive fallback: prompt for the value on stdin (Node.js only). */
+async function defaultOtpHandler(request: OtpRequest): Promise<string> {
+  if (typeof process === "undefined" || !process.stdin) {
+    throw new Error("No interactive stdin available; pass a handler to otpTool().");
+  }
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const label = request.kind === "link" ? "link" : "code";
+    const message = request.source ? `${request.prompt} (sent via ${request.source})` : request.prompt;
+    return await rl.question(`${message}\nEnter the ${label}: `);
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * A ready-made custom tool the agent calls when it needs an OTP, verification code,
+ * or confirmation link. Without a handler, the tool prompts interactively on stdin.
+ *
+ * ```ts
+ * const handler = imapOtpHandler({
+ *   host: "imap.gmail.com",
+ *   username: "agent-inbox@gmail.com",
+ *   password: process.env.GMAIL_APP_PASSWORD!, // Google app password
+ * });
+ * await client.runSession({ agent: "surfer", messages: "Log in to example.com", tools: [otpTool({ handler })] });
+ * ```
+ */
+export function otpTool(options: OtpToolOptions = {}): Tool {
+  const handler = options.handler ?? defaultOtpHandler;
+  return tool({
+    name: options.name ?? OTP_TOOL_NAME,
+    description: options.description ?? OTP_TOOL_DESCRIPTION,
+    inputSchema: OTP_TOOL_INPUT_SCHEMA,
+    fn: async (args) => {
+      const request: OtpRequest = {
+        prompt: typeof args.prompt === "string" ? args.prompt : "The agent needs a one-time password.",
+        kind: args.kind === "link" ? "link" : "code",
+        source: typeof args.source === "string" ? args.source : undefined,
+      };
+      const value = (await handler(request)).trim();
+      if (!value) {
+        throw new Error(`No ${request.kind === "link" ? "link" : "code"} was provided.`);
+      }
+      return value;
+    },
+  });
+}
+
+const OTP_URL = /https?:\/\/[^\s<>"')\]]+/g;
+const OTP_LINK_HINT =
+  /verify|confirm|activat|validat|sign-?in|log-?in|magic|authenticat|authoriz|(?<![a-z])oauth|(?<![a-z])auth(?![a-z])|(?<![a-z])otp(?![a-z])|token/i;
+const OTP_KEYWORD = /(?:code|otp|passcode|password|pin|token)\b/gi;
+const OTP_TOKEN = /\b\d{3,4}(?:[ -]\d{3,4}){1,2}\b|\b[A-Za-z0-9][A-Za-z0-9-]{2,10}[A-Za-z0-9]\b/g;
+const OTP_BARE_CODE = /\b\d{3,4}(?:[ -]\d{3,4}){1,2}\b|\b\d{4,8}\b/;
+
+/**
+ * Best-effort extraction of an OTP code or confirmation link from an email's text.
+ *
+ * Links: prefers a URL that looks like a verification/login link, falling back to the
+ * first URL. Codes: prefers a digit-bearing token near a keyword ("code", "OTP",
+ * "passcode", ...), falling back to any standalone digit run -- contiguous ("482913")
+ * or grouped ("123 456", "1234-5678"). `codePattern` replaces the code heuristics;
+ * its first capture group (or the whole match) is the code.
+ */
+export function extractOtp(text: string, kind: "code" | "link" = "code", codePattern?: RegExp): string | undefined {
+  if (kind === "link") {
+    const urls = text.match(OTP_URL) ?? [];
+    return urls.find((url) => OTP_LINK_HINT.test(url)) ?? urls[0];
+  }
+  if (codePattern) {
+    const match = text.match(codePattern);
+    return match ? (match[1] ?? match[0]) : undefined;
+  }
+  // HTML-derived text carries long whitespace runs (stripped tags, table layouts)
+  // that would push the code out of the keyword window; collapse them first.
+  const collapsed = text.replace(/\s+/g, " ");
+  for (const keyword of collapsed.matchAll(OTP_KEYWORD)) {
+    const start = (keyword.index ?? 0) + keyword[0].length;
+    for (const token of collapsed.slice(start, start + 60).match(OTP_TOKEN) ?? []) {
+      if (/\d/.test(token)) {
+        return token;
+      }
+    }
+  }
+  return collapsed.match(OTP_BARE_CODE)?.[0];
+}
+
+function htmlToText(markup: string): string {
+  const entities: Record<string, string> = { amp: "&", lt: "<", gt: ">", quot: '"', "#39": "'", nbsp: " " };
+  return (
+    markup
+      .replace(/<(?:script|style)\b[^>]*>[\s\S]*?<\/(?:script|style)>/gi, " ")
+      // Surface link targets: html mail hides the URL behind anchor text ("Click here").
+      .replace(/<a\b[^>]*?href=["']([^"']+)["'][^>]*>/gi, " $1 ")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (_, entity: string) => entities[entity] ?? " ")
+  );
+}
+
+export type ImapOtpHandlerOptions = {
+  host: string;
+  username: string;
+  password: string;
+  /** Defaults to 993 (IMAP over TLS). */
+  port?: number;
+  /** Mailbox to poll; defaults to "INBOX". */
+  mailbox?: string;
+  /** Only consider messages from this address, e.g. "no-reply@example.com". */
+  sender?: string;
+  /** Give up (and report a tool error to the agent) after this long; defaults to 2 minutes. */
+  timeoutMs?: number;
+  /** Delay between mailbox polls; defaults to 5 seconds. */
+  pollIntervalMs?: number;
+  /** Ignore unread messages older than this; defaults to 15 minutes. */
+  maxAgeMs?: number;
+  /** Mark the matched message read so a retry cannot reuse a stale code; defaults to true. */
+  markSeen?: boolean;
+  /** Replaces the built-in code heuristics; first capture group (or the whole match) is the code. */
+  codePattern?: RegExp;
+};
+
+// Structural slices of the optional `imapflow` / `mailparser` APIs this handler uses.
+type ImapConnection = {
+  connect(): Promise<unknown>;
+  logout(): Promise<unknown>;
+  getMailboxLock(path: string): Promise<{ release(): void }>;
+  search(query: Record<string, unknown>, options: { uid: true }): Promise<number[] | false>;
+  fetchOne(
+    id: string,
+    query: Record<string, unknown>,
+    options: { uid: true },
+  ): Promise<{ internalDate?: Date; source?: Uint8Array } | false>;
+  messageFlagsAdd(id: string, flags: string[], options: { uid: true }): Promise<unknown>;
+};
+type ImapFlowModule = {
+  ImapFlow: new (config: {
+    host: string;
+    port: number;
+    secure: boolean;
+    auth: { user: string; pass: string };
+    logger: false;
+  }) => ImapConnection;
+};
+type MailparserModule = {
+  simpleParser(source: Uint8Array): Promise<{ subject?: string; text?: string; html?: string | false }>;
+};
+
+async function loadOptional<T>(name: string): Promise<T> {
+  // Non-literal specifier: keeps the optional dependency out of the compile-time module graph.
+  const specifier = name;
+  try {
+    return (await import(specifier)) as T;
+  } catch {
+    throw new Error(`imapOtpHandler requires the optional dependency '${name}': npm install ${name}`);
+  }
+}
+
+/**
+ * An `otpTool` handler that reads the OTP code or confirmation link from a mailbox
+ * over IMAP. Polls the mailbox for unread messages (newest first, at most `maxAgeMs`
+ * old, optionally filtered by `sender`) and runs `extractOtp` on each until one
+ * yields a value; that message is then marked read so a retry cannot reuse a stale
+ * code. Works with any IMAP server (for Gmail / Google Workspace use an app password).
+ *
+ * Privacy: like every custom tool, this runs entirely in your process. The IMAP
+ * credentials and connection stay on your machine and are never sent to the API or
+ * the agent. The agent cannot browse or read the mailbox: it only calls the tool,
+ * and the only thing sent back is the single extracted code or link -- never email
+ * bodies, subjects, senders, or any other message content.
+ *
+ * Requires the optional dependencies `imapflow` and `mailparser`.
+ *
+ * ```ts
+ * const handler = imapOtpHandler({
+ *   host: "imap.gmail.com",
+ *   username: "agent-inbox@gmail.com",
+ *   password: process.env.GMAIL_APP_PASSWORD!,
+ *   sender: "no-reply@service-being-logged-into.com",
+ * });
+ * await client.runSession({ agent: "surfer", messages: "Log in to example.com", tools: [otpTool({ handler })] });
+ * ```
+ */
+export function imapOtpHandler(options: ImapOtpHandlerOptions): OtpHandler {
+  const {
+    host,
+    username,
+    password,
+    port = 993,
+    mailbox = "INBOX",
+    sender,
+    timeoutMs = 120_000,
+    pollIntervalMs = 5_000,
+    maxAgeMs = 900_000,
+    markSeen = true,
+    codePattern,
+  } = options;
+  return async (request) => {
+    const { ImapFlow } = await loadOptional<ImapFlowModule>("imapflow");
+    const { simpleParser } = await loadOptional<MailparserModule>("mailparser");
+    const deadline = Date.now() + timeoutMs;
+    const client = new ImapFlow({ host, port, secure: true, auth: { user: username, pass: password }, logger: false });
+    await client.connect();
+    try {
+      for (;;) {
+        const lock = await client.getMailboxLock(mailbox);
+        try {
+          const query: Record<string, unknown> = { seen: false, since: new Date(Date.now() - maxAgeMs) };
+          if (sender) {
+            query.from = sender;
+          }
+          const uids = (await client.search(query, { uid: true })) || [];
+          for (const uid of [...uids].sort((a, b) => b - a)) {
+            const message = await client.fetchOne(String(uid), { source: true, internalDate: true }, { uid: true });
+            if (!message || !message.source) {
+              continue;
+            }
+            if (message.internalDate && Date.now() - message.internalDate.getTime() > maxAgeMs) {
+              continue;
+            }
+            const parsed = await simpleParser(message.source);
+            const text = [
+              parsed.subject ?? "",
+              parsed.text ?? "",
+              typeof parsed.html === "string" ? htmlToText(parsed.html) : "",
+            ].join("\n");
+            const value = extractOtp(text, request.kind, codePattern);
+            if (value) {
+              if (markSeen) {
+                await client.messageFlagsAdd(String(uid), ["\\Seen"], { uid: true });
+              }
+              return value;
+            }
+          }
+        } finally {
+          lock.release();
+        }
+        if (Date.now() >= deadline) {
+          const label = request.kind === "link" ? "link" : "code";
+          throw new Error(`No ${label} found in unread mail for ${username} within ${Math.round(timeoutMs / 1000)}s.`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      }
+    } finally {
+      await Promise.resolve(client.logout()).catch(() => {});
+    }
+  };
+}

--- a/packages/sdk/src/tools/otp.ts
+++ b/packages/sdk/src/tools/otp.ts
@@ -275,19 +275,25 @@ export function imapOtpHandler(options: ImapOtpHandlerOptions): OtpHandler {
           }
           const uids = (await client.search(query, { uid: true })) || [];
           for (const uid of [...uids].sort((a, b) => b - a)) {
-            const message = await client.fetchOne(String(uid), { source: true, internalDate: true }, { uid: true });
-            if (!message || !message.source) {
+            let text: string;
+            try {
+              const message = await client.fetchOne(String(uid), { source: true, internalDate: true }, { uid: true });
+              if (!message || !message.source) {
+                continue;
+              }
+              if (message.internalDate && Date.now() - message.internalDate.getTime() > maxAgeMs) {
+                continue;
+              }
+              const parsed = await simpleParser(message.source);
+              text = [
+                parsed.subject ?? "",
+                parsed.text ?? "",
+                typeof parsed.html === "string" ? htmlToText(parsed.html) : "",
+              ].join("\n");
+            } catch {
+              // One malformed or oversized message must not abort the poll; skip it.
               continue;
             }
-            if (message.internalDate && Date.now() - message.internalDate.getTime() > maxAgeMs) {
-              continue;
-            }
-            const parsed = await simpleParser(message.source);
-            const text = [
-              parsed.subject ?? "",
-              parsed.text ?? "",
-              typeof parsed.html === "string" ? htmlToText(parsed.html) : "",
-            ].join("\n");
             const value = extractOtp(text, request.kind, codePattern);
             if (value) {
               if (markSeen) {

--- a/packages/sdk/tests/otp.test.ts
+++ b/packages/sdk/tests/otp.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { OTP_TOOL_INPUT_SCHEMA, extractOtp, imapOtpHandler, otpTool } from "../src/tools/otp.js";
+import type { OtpRequest } from "../src/tools/otp.js";
+
+describe("otpTool", () => {
+  it("builds the default definition", () => {
+    const t = otpTool();
+    expect(t.name).toBe("request_otp");
+    expect(t.description).toContain("one-time password");
+    const schema = t.inputSchema as { type: string; required: string[]; properties: Record<string, unknown> };
+    expect(schema.type).toBe("object");
+    expect(schema.required).toEqual(["prompt"]);
+    expect(Object.keys(schema.properties).sort()).toEqual(["kind", "prompt", "source"]);
+  });
+
+  it("passes the request to the handler and trims the value", async () => {
+    const seen: OtpRequest[] = [];
+    const t = otpTool({
+      handler: (request) => {
+        seen.push(request);
+        return "  123456  ";
+      },
+    });
+    await expect(t.fn({ prompt: "Enter the code sent to a@b.com", kind: "code", source: "email" })).resolves.toBe(
+      "123456",
+    );
+    expect(seen).toEqual([{ prompt: "Enter the code sent to a@b.com", kind: "code", source: "email" }]);
+  });
+
+  it("defaults kind and source", async () => {
+    const seen: OtpRequest[] = [];
+    const t = otpTool({
+      handler: (request) => {
+        seen.push(request);
+        return "ok";
+      },
+    });
+    await t.fn({ prompt: "Enter the code" });
+    expect(seen).toEqual([{ prompt: "Enter the code", kind: "code", source: undefined }]);
+  });
+
+  it("rejects empty values", async () => {
+    await expect(otpTool({ handler: () => "   " }).fn({ prompt: "Enter the code" })).rejects.toThrow(
+      "No code was provided.",
+    );
+    await expect(otpTool({ handler: () => "" }).fn({ prompt: "Open the link", kind: "link" })).rejects.toThrow(
+      "No link was provided.",
+    );
+  });
+
+  it("supports async handlers", async () => {
+    const t = otpTool({ handler: async () => " 654321 " });
+    await expect(t.fn({ prompt: "Enter the code" })).resolves.toBe("654321");
+  });
+
+  it("supports name and description overrides", () => {
+    const t = otpTool({ handler: () => "x", name: "get_2fa_code", description: "Fetch the 2FA code." });
+    expect(t.name).toBe("get_2fa_code");
+    expect(t.description).toBe("Fetch the 2FA code.");
+    expect(t.inputSchema).toBe(OTP_TOOL_INPUT_SCHEMA);
+  });
+});
+
+describe("extractOtp", () => {
+  it("finds a code near a keyword", () => {
+    expect(extractOtp("Your verification code is 482913. It expires in 10 minutes.")).toBe("482913");
+    expect(extractOtp("Your OTP code is 1234")).toBe("1234");
+  });
+
+  it("finds grouped digits", () => {
+    expect(extractOtp("Enter 123 456 to continue")).toBe("123 456");
+    expect(extractOtp("Your code is 1234-5678")).toBe("1234-5678");
+    expect(extractOtp("Use 123 456 789 now")).toBe("123 456 789");
+  });
+
+  it("collapses whitespace from html layouts", () => {
+    // Table-based HTML mail turns into text with the code far from the keyword.
+    const text = "Your verification code\n\n\n" + " ".repeat(50) + "\n\n482913";
+    expect(extractOtp(text)).toBe("482913");
+  });
+
+  it("finds alphanumeric codes", () => {
+    expect(extractOtp("Use passcode 7GK4-P2Q to continue.")).toBe("7GK4-P2Q");
+  });
+
+  it("falls back to bare digits", () => {
+    expect(extractOtp("314159 is your Acme sign-in key")).toBe("314159");
+  });
+
+  it("honors a custom pattern's capture group", () => {
+    expect(extractOtp("Ticket ABC-99-XYZ opened", "code", /Ticket ([A-Z0-9-]+)/)).toBe("ABC-99-XYZ");
+  });
+
+  it("prefers verification-looking links", () => {
+    const text =
+      "View in browser: https://news.example.com/open?id=1 Confirm: https://app.example.com/verify?token=abc";
+    expect(extractOtp(text, "link")).toBe("https://app.example.com/verify?token=abc");
+  });
+
+  it("ignores hint words embedded in other words", () => {
+    // "authors" / "hotpicks" must not trip the "auth" / "otp" hints and outrank the real link.
+    const text =
+      "Meet our team: https://blog.example.com/authors/jane " +
+      "Deals: https://shop.example.com/hotpicks " +
+      "Confirm your account: https://app.example.com/verify?id=1";
+    expect(extractOtp(text, "link")).toBe("https://app.example.com/verify?id=1");
+  });
+
+  it("still matches auth path segments", () => {
+    expect(extractOtp("Docs: https://docs.example.com/start Login: https://id.example.com/auth/callback?sid=9", "link")).toBe(
+      "https://id.example.com/auth/callback?sid=9",
+    );
+    expect(extractOtp("Docs: https://docs.example.com/start Login: https://oauth.example.com/approve?sid=9", "link")).toBe(
+      "https://oauth.example.com/approve?sid=9",
+    );
+  });
+
+  it("falls back to the first url", () => {
+    expect(extractOtp("See https://example.com/a then https://example.com/b", "link")).toBe("https://example.com/a");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(extractOtp("Hello there, nothing to see.")).toBeUndefined();
+    expect(extractOtp("Hello there, nothing to see.", "link")).toBeUndefined();
+  });
+});
+
+describe("imapOtpHandler", () => {
+  it("reports the missing optional dependency", async () => {
+    const handler = imapOtpHandler({ host: "imap.test", username: "u@test", password: "pw" });
+    await expect(handler({ prompt: "Enter the code", kind: "code" })).rejects.toThrow(
+      "imapOtpHandler requires the optional dependency 'imapflow'",
+    );
+  });
+});

--- a/packages/sdk/tests/otpImap.test.ts
+++ b/packages/sdk/tests/otpImap.test.ts
@@ -1,0 +1,56 @@
+/**
+ * imapOtpHandler behavior against mocked `imapflow` / `mailparser` modules.
+ *
+ * Kept separate from otp.test.ts: the mocks below are file-scoped, and otp.test.ts
+ * asserts the missing-optional-dependency error for these very modules.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { imapOtpHandler } from "../src/tools/otp.js";
+
+const state = vi.hoisted(() => ({
+  flagged: [] as Array<{ id: string; flags: string[] }>,
+  fetched: [] as string[],
+}));
+
+vi.mock("imapflow", () => {
+  class FakeImapFlow {
+    async connect() {}
+    async logout() {}
+    async getMailboxLock(_path: string) {
+      return { release() {} };
+    }
+    async search(_query: Record<string, unknown>, _options: { uid: true }) {
+      return [1, 2];
+    }
+    async fetchOne(id: string, _query: Record<string, unknown>, _options: { uid: true }) {
+      state.fetched.push(id);
+      // The newest message (uid 2, polled first) is broken; the older one carries the code.
+      const body = id === "2" ? "BOOM" : "Your login code is 271828.";
+      return { internalDate: new Date(), source: new TextEncoder().encode(body) };
+    }
+    async messageFlagsAdd(id: string, flags: string[], _options: { uid: true }) {
+      state.flagged.push({ id, flags });
+    }
+  }
+  return { ImapFlow: FakeImapFlow };
+});
+
+vi.mock("mailparser", () => ({
+  simpleParser: async (source: Uint8Array) => {
+    const text = new TextDecoder().decode(source);
+    if (text.includes("BOOM")) {
+      throw new Error("malformed message");
+    }
+    return { subject: "Your login code", text };
+  },
+}));
+
+describe("imapOtpHandler with a mocked mailbox", () => {
+  it("skips a message that fails to fetch or parse and keeps polling", async () => {
+    const handler = imapOtpHandler({ host: "imap.test", username: "u@test", password: "pw" });
+    await expect(handler({ prompt: "Enter the code", kind: "code" })).resolves.toBe("271828");
+    expect(state.fetched).toEqual(["2", "1"]);
+    expect(state.flagged).toEqual([{ id: "1", flags: ["\\Seen"] }]);
+  });
+});


### PR DESCRIPTION
## feat: prebuilt OTP tool
Adds hand-written prebuilt custom tools under `packages/sdk/src/tools/`,
starting with an OTP tool for logins that need two-factor codes.
### What's new
- **`otpTool`** — a ready-made custom tool the agent calls when a login,
  signup, or verification step asks for a one-time password, verification
  code, or confirmation link. The handler resolves the value: interactively
  on stdin by default (Node.js), or programmatically (inbox API, Slack
  prompt, ...).
- **`imapOtpHandler`** — a handler that polls a mailbox over IMAP for
  unread messages (newest first, optionally filtered by sender), extracts
  the code or link, and marks the matched message read so a retry cannot
  reuse a stale code. Requires the optional dependencies `imapflow` and
  `mailparser` (loaded lazily; a clear error tells you to install them).
  Works with any IMAP server; for Gmail use an app password.
- **`extractOtp`** — best-effort extraction heuristics for codes
  (keyword-proximity, grouped digits, alphanumeric tokens, custom pattern
  override) and confirmation links (verification-looking URLs preferred).
```ts
import { HaiAgentsClient, imapOtpHandler, otpTool } from "hai-agents";
const handler = imapOtpHandler({
  host: "imap.gmail.com",
  username: "agent-inbox@gmail.com",
  password: process.env.GMAIL_APP_PASSWORD!,
});
const result = await new HaiAgentsClient().runSession({
  agent: "h/web-surfer-pro",
  messages: "Log in to example.com",
  tools: [otpTool({ handler })],
});
```

Privacy: like every custom tool, the handler runs entirely in your process. IMAP credentials never leave your machine; the agent only receives the single extracted code or link — never mailbox contents.

Structure
src/tools/ is hand-written and maintained in this repository, outside the regenerated src/client tree. It builds on the tool plumbing (tool, Tool) shipped with the generated client and is re-exported from the package entrypoint (src/index.ts), so everything stays importable from the package root.

Tests
tests/otp.test.ts — tool definition, handler contract (trimming, empty values, async handlers, name/description overrides), extraction heuristics, and the missing-optional-dependency error path.
Verified against the built dist/ output in both ESM and CJS.
README (root and packages/sdk) gains a "Prebuilt: one-time passwords (2FA)" section.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New login/2FA path and IMAP credential handling in user processes; extraction heuristics could pick the wrong code/link, but secrets are not sent to the API beyond the resolved OTP value.
> 
> **Overview**
> Adds **prebuilt 2FA tooling** under `packages/sdk/src/tools/` and re-exports it from the package root so agents can request OTPs, verification codes, or confirmation links during login flows.
> 
> **`otpTool`** is a custom `request_otp` tool built on existing `tool()` plumbing: the agent supplies `prompt`, optional `kind` (`code` | `link`), and `source`; a pluggable handler returns the value (trimmed, with errors on empty input). Default behavior prompts on **stdin** in Node when no handler is passed.
> 
> **`imapOtpHandler`** optionally polls IMAP (`imapflow` / `mailparser` loaded at runtime) for recent unread mail, parses bodies, runs **`extractOtp`** heuristics (keyword-near codes, grouped digits, verification URLs, custom `codePattern`), marks the winning message read, and only returns the extracted code or link—not full email content. Root and SDK READMEs document usage and the local-only credential model.
> 
> Vitest covers tool contract, extraction edge cases, missing optional deps, and mocked IMAP skip-on-parse-failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1399e0fd14f7c0e048e82efafcb2f62239862334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->