### PR TITLE
chore(sdk): sync generated SDK (v1.0.7)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7054,6 +7054,34 @@
             "title": "Idle Timeout S",
             "description": "Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers."
           },
+          "delete_after_min": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delete After Min",
+            "description": "Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever.",
+            "default": 43200
+          },
+          "delete_screenshot_after_min": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delete Screenshot After Min",
+            "description": "Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime.",
+            "default": 43200
+          },
           "queue": {
             "type": "boolean",
             "title": "Queue",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai-agents",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "TypeScript SDK for H Company's Computer-Use Agents: autonomous agents powered by Holo.",
   "keywords": [
     "agent",

--- a/packages/sdk/src/client/BaseClient.ts
+++ b/packages/sdk/src/client/BaseClient.ts
@@ -57,9 +57,9 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
 ): NormalizedClientOptions<T> {
     const headers = mergeHeaders(
         {
-            "User-Agent": "hai-agents/1.0.6",
+            "User-Agent": "hai-agents/1.0.7",
             "X-HCompany-Client-Name": "hai-agents",
-            "X-HCompany-Client-Version": "1.0.6",
+            "X-HCompany-Client-Version": "1.0.7",
             "X-HCompany-Client-Type": "sdk",
             "X-HCompany-Language": "JavaScript",
             "X-HCompany-Runtime": core.RUNTIME.type,

--- a/packages/sdk/src/client/api/types/SessionRequest.ts
+++ b/packages/sdk/src/client/api/types/SessionRequest.ts
@@ -16,6 +16,10 @@ export interface SessionRequest {
     maxTimeS?: number | null;
     /** Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers. */
     idleTimeoutS?: number | null;
+    /** Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever. */
+    deleteAfterMin?: number | null;
+    /** Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime. */
+    deleteScreenshotAfterMin?: number | null;
     /** When the organization is at its concurrent-session limit, accept this session into a queue (status 'queued') instead of rejecting it with 429. Queued sessions start automatically, oldest first, as running sessions finish. Set to false to get an immediate 429 when no slot is available. */
     queue?: boolean;
     /** Optional id to group and list related sessions together. */

--- a/packages/sdk/src/client/serialization/types/SessionRequest.ts
+++ b/packages/sdk/src/client/serialization/types/SessionRequest.ts
@@ -13,6 +13,11 @@ export const SessionRequest: core.serialization.ObjectSchema<serializers.Session
         maxSteps: core.serialization.property("max_steps", core.serialization.number().optionalNullable()),
         maxTimeS: core.serialization.property("max_time_s", core.serialization.number().optionalNullable()),
         idleTimeoutS: core.serialization.property("idle_timeout_s", core.serialization.number().optionalNullable()),
+        deleteAfterMin: core.serialization.property("delete_after_min", core.serialization.number().optionalNullable()),
+        deleteScreenshotAfterMin: core.serialization.property(
+            "delete_screenshot_after_min",
+            core.serialization.number().optionalNullable(),
+        ),
         queue: core.serialization.boolean().optional(),
         groupId: core.serialization.property("group_id", core.serialization.string().optionalNullable()),
         parentSessionId: core.serialization.property(
@@ -29,6 +34,8 @@ export declare namespace SessionRequest {
         max_steps?: (number | null | undefined) | null;
         max_time_s?: (number | null | undefined) | null;
         idle_timeout_s?: (number | null | undefined) | null;
+        delete_after_min?: (number | null | undefined) | null;
+        delete_screenshot_after_min?: (number | null | undefined) | null;
         queue?: boolean | null;
         group_id?: (string | null | undefined) | null;
         parent_session_id?: (string | null | undefined) | null;


### PR DESCRIPTION
Auto-generated from the upstream codegen home.

**Version:** `1.0.7` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@b465068